### PR TITLE
fix renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,8 +13,11 @@
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",
   "suppressNotifications": ["prIgnoreNotification"],
   "commitBodyTable": true,
-  "excludePackagePatterns": ["alpine", "ubuntu"],
   "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["!alpine", "!ubuntu"],
+    },
     {
       "description": "Auto-merge Github Actions",
       "matchDatasources": ["github-tags"],


### PR DESCRIPTION
Should fix #586 

I think this should take care of skipping the packages.
https://docs.renovatebot.com/configuration-options/#matchpackagenames