### PR TITLE
try to fix renovate again

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,7 +33,7 @@
       "automergeType": "branch",
       "platformAutomerge": true,
       "ignoreTests": true,
-      "excludePackagePatterns": ["alpine", "ubuntu"]
+      "matchPackageNames": ["!alpine", "!ubuntu"]
     }, 
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
I can't find the `excludePackagePatterns` in the docs on any level of the config.
It seems that have been removed completely (based on some searching on renovates code)