### PR TITLE
feat(riven): ensure zurg url can be dynamically set at runtime using ZURG_URL

### DIFF
--- a/apps/riven/riven.sh
+++ b/apps/riven/riven.sh
@@ -30,8 +30,8 @@ fi
 #echo "📺 Waiting for plex to be up..."
 #/usr/local/bin/wait-for -t 3600 plex:32400 -- echo "✅"
 
-echo "👽 Waiting for zurg to be up..."
-/usr/local/bin/wait-for -t 3600 zurg:9999 -- echo "✅"
+echo "👽 Waiting for zurg to be up in ${ZURG_URL:-"zurg:9999"}..."
+/usr/local/bin/wait-for -t 3600 ${ZURG_URL:-"zurg:9999"} -- echo "✅"
 
 echo "🎉 let's go!"
 poetry run python3 main.py 


### PR DESCRIPTION
The current use of hardcoded zurg-url, makes the container (borderline) unusable outside of ElfHosted, this simple fix makes the zurg url dynamically adjustable, without interfering with defaults