### PR TITLE
Migrate dashboard-icons to homarr-labs

### DIFF
--- a/apps/homer/Dockerfile
+++ b/apps/homer/Dockerfile
@@ -58,7 +58,7 @@ RUN rm -rf /www/assets/* && \
 	rm main.zip && \
 	rm -rf home-theme-main && \
 
-	wget https://github.com/walkxcode/dashboard-icons/archive/refs/heads/main.zip && \
+	wget https://github.com/homarr-labs/dashboard-icons/archive/refs/heads/main.zip && \
 	unzip main.zip && \
 	mv dashboard-icons-main/png ./ && \
 	rm main.zip && \


### PR DESCRIPTION
Info: https://github.com/homarr-labs/dashboard-icons/discussions/797#discussioncomment-11736264.

_Note: The walkxcode/dashboard-icons repository will continue to function indefinitely but may no longer receive updates._