### PR TITLE
feat(elrond-debridge): CI build metadata for the debridge diagnostics MCP

### DIFF
--- a/apps/elrond-debridge/ci/latest.sh
+++ b/apps/elrond-debridge/ci/latest.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+version=$(curl -sX GET https://api.github.com/repos/elfhosted/elrond/releases/latest --header "Authorization: Bearer ${ZURG_GH_CREDS}" | jq --raw-output '. | .tag_name')
+printf "%s" "${version}"

--- a/apps/elrond-debridge/metadata.json
+++ b/apps/elrond-debridge/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "elrond-debridge",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
New container app `elrond-debridge` — CI build metadata (`metadata.json` + `ci/latest.sh`) for the Elrond debridge diagnostics MCP. Mirrors `elrond-woo`. The Dockerfile lives in `containers-private/apps/elrond-debridge`.

Paired with elfhosted/elrond#76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)