### PR TITLE
feat(elrond-shadowfax): CI build metadata for the shadowfax diagnostics MCP

### DIFF
--- a/apps/elrond-shadowfax/ci/latest.sh
+++ b/apps/elrond-shadowfax/ci/latest.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+version=$(curl -sX GET https://api.github.com/repos/elfhosted/elrond/releases/latest --header "Authorization: Bearer ${ZURG_GH_CREDS}" | jq --raw-output '. | .tag_name')
+printf "%s" "${version}"

--- a/apps/elrond-shadowfax/metadata.json
+++ b/apps/elrond-shadowfax/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "elrond-shadowfax",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds the **public** build metadata for `elrond-shadowfax` — the missing half of the image build. The Dockerfile is in `containers-private` (merged), but without `metadata.json` + `ci/latest.sh` here, `fetch.sh` never discovers the app and the image never builds.

Mirrors `elrond-debridge`/`elrond-woo` exactly:
- **`metadata.json`** — app `elrond-shadowfax`, channel `main`, linux/amd64, tests disabled.
- **`ci/latest.sh`** — byte-identical to the siblings; resolves the upstream version via `elfhosted/elrond/releases/latest` (currently **v2.24.0**, which ships `shadowfax-mcp`).

Once merged, the next `Release: Schedule` run detects the app has no published image, builds it by cloning elrond at v2.24.0, and publishes `ghcr.io/elfhosted/elrond-shadowfax:v2.24.0@sha256:…` — which then gets pinned in infra#15672.

Verified: `latest.sh` diff-identical to `elrond-debridge`, executable (100755), valid JSON, `bash -n` clean; `elfhosted/elrond/releases/latest` → v2.24.0.