### PR TITLE
fix(toast-translator): stop crashloop on list-valued imdb_id

### DIFF
--- a/apps/toast-translator/Dockerfile
+++ b/apps/toast-translator/Dockerfile
@@ -6,7 +6,17 @@ ARG VERSION
 RUN apk update && apk upgrade && \
     apk add --no-cache git
 
-RUN git clone https://github.com/qwertyuiop8899/toast-translator.git /source
+# Pin to the exact upstream commit the patch in apps/toast-translator/patches/
+# was generated against. Cloning a floating `main` would let `git apply` break
+# silently the moment upstream pushes a commit touching anime/anime_mapping.py.
+# Bump this SHA (and rebase the patch) in lockstep with upstream.
+RUN git clone https://github.com/qwertyuiop8899/toast-translator.git /source && \
+    git -C /source checkout 97e2d8baa4fd71c3f30ed658170bba51565f6c33
+
+# Apply our patches. `|| exit 1` so a non-applying patch FAILS the build instead
+# of silently shipping an image missing the fix.
+COPY apps/toast-translator/patches/ /patches/
+RUN for p in /patches/*.patch; do echo "applying $p"; git -C /source apply "$p" || exit 1; done
 
 FROM python:3.10-slim-buster
 WORKDIR /app

--- a/apps/toast-translator/patches/0001-fix-handle-list-valued-imdb_id-from-Fribb-anime-list.patch
+++ b/apps/toast-translator/patches/0001-fix-handle-list-valued-imdb_id-from-Fribb-anime-list.patch
@@ -1,0 +1,110 @@
+From 8b92ba4651fe0b44e9512f208a533c43d904c564 Mon Sep 17 00:00:00 2001
+From: David Young <davidy@funkypenguin.co.nz>
+Date: Wed, 8 Jul 2026 20:29:03 +1200
+Subject: [PATCH] fix: handle list-valued imdb_id from Fribb/anime-lists
+
+Fribb/anime-lists (fetched at startup) now emits some entries whose
+imdb_id is a list of IMDb IDs (a title with multiple IDs). load_imdb_map
+used imdb_id directly as a dict key (if imdb_id not in map / map[imdb_id]),
+raising TypeError: unhashable type: 'list' during app startup -> crashloop.
+
+Normalize imdb_id to a list via _imdb_ids() and map each id. Also apply the
+same normalization in load_kitsu_map/load_mal_map, which previously matched
+'tt' in imdb_id and silently dropped list-valued entries.
+---
+ anime/anime_mapping.py | 53 ++++++++++++++++++++++++------------------
+ 1 file changed, 31 insertions(+), 22 deletions(-)
+
+diff --git a/anime/anime_mapping.py b/anime/anime_mapping.py
+index ab015e0..b421135 100644
+--- a/anime/anime_mapping.py
++++ b/anime/anime_mapping.py
+@@ -31,6 +31,15 @@ async def download_maps():
+         anime_season_map = {**results[1].json(), **anidb_extension}
+         
+ 
++def _imdb_ids(imdb_id):
++    """Fribb/anime-lists may provide imdb_id as a single string or a list of
++    strings (a title with multiple IMDb IDs). Normalize to a list of ids so
++    callers can key/iterate safely instead of crashing on the unhashable list."""
++    if isinstance(imdb_id, list):
++        return [i for i in imdb_id if i]
++    return [imdb_id] if imdb_id else []
++
++
+ def load_kitsu_map() -> dict:
+     """
+     Mappa per convertire un id kitsu in un id imdb
+@@ -40,8 +49,8 @@ def load_kitsu_map() -> dict:
+ 
+     for item in raw_map:
+         kitsu_id = item.get('kitsu_id', None)
+-        imdb_id = item.get('imdb_id', None)
+-        if kitsu_id != None and imdb_id != None and 'tt' in imdb_id:
++        imdb_id = next((i for i in _imdb_ids(item.get('imdb_id')) if 'tt' in i), None)
++        if kitsu_id != None and imdb_id != None:
+             mapping_list[kitsu_id] = imdb_id
+ 
+     return mapping_list
+@@ -56,8 +65,8 @@ def load_mal_map() -> dict:
+ 
+     for item in raw_map:
+         mal_id = item.get('mal_id', None)
+-        imdb_id = item.get('imdb_id', None)
+-        if mal_id != None and imdb_id != None and 'tt' in imdb_id:
++        imdb_id = next((i for i in _imdb_ids(item.get('imdb_id')) if 'tt' in i), None)
++        if mal_id != None and imdb_id != None:
+             mapping_list[mal_id] = imdb_id
+ 
+     return mapping_list
+@@ -78,29 +87,29 @@ def load_imdb_map() -> dict:
+ 
+     for item in raw_map:
+ 
+-        imdb_id: str | None = item.get('imdb_id')
++        imdb_ids = _imdb_ids(item.get('imdb_id'))
+ 
+-        if imdb_id != None:
++        if imdb_ids:
+             kitsu_id: str | None = item.get('kitsu_id')
+             anidb_id: str | None  = item.get('anidb_id')
+             mal_id: str | None  = item.get('mal_id')
+ 
+-            # Create
+-            if imdb_id not in map:
+-                map[imdb_id] = {
+-                    "kitsu_ids": [],
+-                    "anidb_ids": [],
+-                    "mal_ids": []
+-                }
+-                
+-            # Update
+-            if kitsu_id != None and anidb_id != None:
+-                kitsu_id, anidb_id = str(kitsu_id), str(anidb_id)
+-                map[imdb_id]['anidb_ids'].append(anidb_id)
+-                insert_sorted_kitsu_insort(map[imdb_id]['kitsu_ids'], kitsu_id, anidb_map[anidb_id].get('tvdb_season'), anidb_map[anidb_id].get('tvdb_epoffset'))
+-            if mal_id != None:
+-                mal_id = str(mal_id)
+-                map[imdb_id]['mal_ids'].append(mal_id)
++            for imdb_id in imdb_ids:
++                # Create
++                if imdb_id not in map:
++                    map[imdb_id] = {
++                        "kitsu_ids": [],
++                        "anidb_ids": [],
++                        "mal_ids": []
++                    }
++
++                # Update
++                if kitsu_id != None and anidb_id != None:
++                    kitsu_id_s, anidb_id_s = str(kitsu_id), str(anidb_id)
++                    map[imdb_id]['anidb_ids'].append(anidb_id_s)
++                    insert_sorted_kitsu_insort(map[imdb_id]['kitsu_ids'], kitsu_id_s, anidb_map[anidb_id_s].get('tvdb_season'), anidb_map[anidb_id_s].get('tvdb_epoffset'))
++                if mal_id != None:
++                    map[imdb_id]['mal_ids'].append(str(mal_id))
+ 
+     return map
+ 
+-- 
+2.54.0
+


### PR DESCRIPTION
## Incident

`toast-translator` has been crashlooping **fleet-wide** (deployment `0/2` Ready), every replica dying identically at startup:

```
File "/app/anime/anime_mapping.py", line 89, in load_imdb_map
    if imdb_id not in map:
TypeError: unhashable type: 'list'
```

## Root cause

The anime map is fetched **at startup** from `Fribb/anime-lists`, which now emits some entries whose `imdb_id` is a **list** of IMDb IDs (a title with multiple IDs). `load_imdb_map` used `imdb_id` directly as a dict key (`if imdb_id not in map` / `map[imdb_id]`), which throws on the unhashable list → startup fails → `CrashLoopBackOff`.

It's a **runtime-data** change, not a code regression — so pinning/rolling back the image does nothing; it needs a code fix. Both replicas fail identically because it's deterministic startup data, confirming it's unrelated to any node/scheduling issue.

## Fix

Upstream is a third-party repo we clone at build time, so this is carried as a **patch** (`apps/toast-translator/patches/0001-*.patch`):

- Add `_imdb_ids()` to normalize `imdb_id` (str **or** list) to a list.
- `load_imdb_map`: iterate the normalized list so each id is mapped (a multi-IMDb title now maps *all* its ids).
- `load_kitsu_map` / `load_mal_map`: same normalization — they previously matched `'tt' in imdb_id` and **silently dropped** list-valued entries.

Build hardening (matches the nzbdav convention):
- Pin the upstream clone to `97e2d8b` (current `main` HEAD — i.e. exactly what the floating build produced anyway) so `git apply` is deterministic.
- `git apply ... || exit 1` so a non-applying patch **fails the build** instead of silently shipping the image without the fix.

## Verification

- `git apply --check` passes on a fresh clone at the pinned SHA; result compiles.
- Unit test: an entry with `imdb_id: ["tt0002","tt0003"]` no longer crashes and expands to **both** keys, each carrying the kitsu/anidb/mal data; scalar entries unchanged.

## Ops note

Once this image rolls out, the crashloop clears. Separately, the `minAvailable: 1` PDB on this 2-replica deploy is what turned "app is broken" into "node drains are blocked" — worth switching to `maxUnavailable: 1` so a crashlooped replica can't deadlock maintenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
