### PR TITLE
feat(hermes): public metadata + version detection

### DIFF
--- a/apps/hermes/ci/latest.sh
+++ b/apps/hermes/ci/latest.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Hermes Agent uses date-based CalVer tags (e.g. v2026.7.7.2). The git tag is
+# returned verbatim (with leading "v") because the Dockerfile clones -b $VERSION.
+channel="${1:-stable}"
+repo="nousresearch/hermes-agent"
+
+gh_curl() {
+  if [[ -n "${TOKEN-}" ]]; then
+    curl -fsSL -H "Authorization: Bearer ${TOKEN}" "$@"
+  else
+    curl -fsSL "$@"
+  fi
+}
+
+case "$channel" in
+  dev)
+    version="$(gh_curl "https://api.github.com/repos/${repo}/commits/main" | jq -r '.sha[0:7]')"
+    ;;
+  *)
+    version="$(gh_curl "https://api.github.com/repos/${repo}/releases/latest" | jq -r '.tag_name')"
+    ;;
+esac
+
+printf '%s' "${version}"

--- a/apps/hermes/metadata.json
+++ b/apps/hermes/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "hermes",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Part of the Hermes Agent (Nous Research) rollout. Adds the public container definition:

- `apps/hermes/metadata.json` — web app, stable `main` channel, goss tests enabled
- `apps/hermes/ci/latest.sh` — returns Hermes' CalVer git tag verbatim (e.g. `v2026.7.7.2`) for the Dockerfile clone

Dockerfile + goss live in containers-private (paired PR). After merge, trigger `Release: Manual` for `hermes` to build the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)