### PR TITLE
feat(digarr): add digarr, AI music discovery for Lidarr (EEP-124)

### DIFF
--- a/apps/digarr/ci/latest.sh
+++ b/apps/digarr/ci/latest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+version=$(curl -sX GET "https://api.github.com/repos/iuliandita/digarr/releases/latest" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.tag_name')
+version="${version#*v}"
+printf "%s" "${version}"

--- a/apps/digarr/metadata.json
+++ b/apps/digarr/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "digarr",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds `digarr` (https://github.com/iuliandita/digarr, MIT, v1.12.0): metadata.json (main channel, goss web test enabled) + GitHub-releases latest.sh.

Companion PRs: containers-private (Dockerfile/goss/icon), myprecious (chart, base=dev), docs, tenants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)