### PR TITLE
feat(scryer): add container image (EEP-119)

### DIFF
--- a/apps/scryer/ci/latest.sh
+++ b/apps/scryer/ci/latest.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+version=$(curl -sX GET "https://api.github.com/repos/scryer-media/scryer/releases/latest" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.tag_name')
+# Upstream tags are prefixed "scryer-v" (e.g. scryer-v0.16.8)
+version="${version#scryer-v}"
+printf "%s" "${version}"

--- a/apps/scryer/metadata.json
+++ b/apps/scryer/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "scryer",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds the public container definition for **Scryer** (EEP-119), a Rust-native media manager for movies/TV/anime, positioned as an *arr-stack alternative.

- `apps/scryer/metadata.json` — main channel, linux/amd64, web goss test enabled
- `apps/scryer/ci/latest.sh` — GitHub releases; strips the upstream `scryer-v` tag prefix (e.g. `scryer-v0.16.8` → `0.16.8`)

Upstream: https://github.com/scryer-media/scryer (GPL-3.0)
Dockerfile + goss live in containers-private (companion PR).

Built & goss-verified locally (process running, `/healthz` → 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)