### PR TITLE
feat(trawl): add Camoufox-based FlareSolverr alternative

### DIFF
--- a/apps/trawl/ci/latest.sh
+++ b/apps/trawl/ci/latest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+version=$(curl -sX GET "https://api.github.com/repos/germondai/trawl/releases/latest" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.tag_name')
+version="${version#*v}"
+printf "%s" "${version}"

--- a/apps/trawl/metadata.json
+++ b/apps/trawl/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "trawl",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Public scaffold for **trawl** (germondai/trawl) — a Camoufox/Bun tiered scraping engine that exposes a FlareSolverr-compatible \`/v1\` API on 8191.

Evaluated as a lower-latency, fast-failing alternative to our FlareSolverr fleet. Over 24h the fleet ran ~2.7 cores / ~9GiB to serve 140 req/day at 49% success, every failure a 990s challenge-grind against 1337x. Local testing solved eztvx.to in 3.6s (vs the fleet's 59s median) and failed the 1337x case in ~5s instead of 16 minutes.

- \`metadata.json\` — main channel, web test enabled (goss gates on \`/health\`, which the private image patches to only 200 once a browser is warm)
- \`ci/latest.sh\` — GitHub releases, strips \`v\` prefix

Dockerfile + goss + health patch are in containers-private (elfhosted/containers-private#feat/trawl). Infra swapover in the infra repo (feat/trawl-swapover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)