### PR TITLE
feat(pdns-auth-49): re-host upstream PowerDNS auth 4.9 LTS image

### DIFF
--- a/apps/pdns-auth-49/ci/latest.sh
+++ b/apps/pdns-auth-49/ci/latest.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Highest 4.9.x tag of the upstream PowerDNS Authoritative 4.9 LTS image.
+# We re-host it (ghcr.io/elfhosted/pdns-auth-49) so the direct-dns PowerDNS
+# pods pull from our own registry (Docker Hub anonymous pull limits bite on
+# some DC egress IPs) and get scanned like every other image we ship.
+version=$(curl -s "https://hub.docker.com/v2/repositories/powerdns/pdns-auth-49/tags?page_size=100" \
+  | jq --raw-output '.results[].name' \
+  | grep -E '^4\.9\.[0-9]+$' \
+  | sort -V \
+  | tail -n1)
+printf "%s" "${version}"

--- a/apps/pdns-auth-49/metadata.json
+++ b/apps/pdns-auth-49/metadata.json
@@ -1,0 +1,16 @@
+{
+  "app": "pdns-auth-49",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds `pdns-auth-49` so we build+push `ghcr.io/elfhosted/pdns-auth-49` instead of pulling `docker.io/powerdns/pdns-auth-49` directly. Motivation: every image we run should be under our own registry — avoids Docker Hub anonymous pull limits on DC egress IPs (Leaseweb/OVH), and routes it through our GHCR security scanning.

- `metadata.json` + `ci/latest.sh` here (public); the Dockerfile (pure passthrough, no patches) is in **containers-private#<paired PR>**.
- `latest.sh` tracks the highest `4.9.x` tag (LTS line); resolves `4.9.16` today.
- Tests disabled — pdns-auth needs its gpgsql/CNPG backend to start, so it can't come up standalone in a goss run (same pattern as other DB-dependent apps).

Consumer: infra `direct-dns/` PowerDNS pods (currently on `docker.io`; switches to this image once built). Paired with containers-private PR for the Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)