### PR TITLE
feat(dnsdist-19): re-host upstream dnsdist 1.9 image

### DIFF
--- a/apps/dnsdist-19/ci/latest.sh
+++ b/apps/dnsdist-19/ci/latest.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Highest 1.9.x tag of the upstream dnsdist 1.9 line. Re-hosted as
+# ghcr.io/elfhosted/dnsdist-19 (our registry, GHCR-scanned, no Docker Hub pull
+# limits) — the rate-limiting/anti-abuse frontend for the direct-dns PowerDNS.
+version=$(curl -s "https://hub.docker.com/v2/repositories/powerdns/dnsdist-19/tags?page_size=100" \
+  | jq --raw-output '.results[].name' \
+  | grep -E '^1\.9\.[0-9]+$' \
+  | sort -V \
+  | tail -n1)
+printf "%s" "${version}"

--- a/apps/dnsdist-19/metadata.json
+++ b/apps/dnsdist-19/metadata.json
@@ -1,0 +1,16 @@
+{
+  "app": "dnsdist-19",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds `dnsdist-19` → `ghcr.io/elfhosted/dnsdist-19` (our registry, GHCR-scanned, no Docker Hub pull limits). The rate-limiting / anti-abuse frontend for the direct-dns PowerDNS (per-IP QPS caps, drop-ANY amplification guard, dynamic blocks on abuse patterns, packet cache). Dockerfile (passthrough) in the paired containers-private PR. `latest.sh` tracks highest 1.9.x (1.9.15 today); tests disabled (needs a backend + config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)