### PR TITLE
fix(filebrowser): ignore preview releases

### DIFF
--- a/apps/filebrowser/ci/latest.sh
+++ b/apps/filebrowser/ci/latest.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
-channel=$1
-version=$(curl -sX GET "https://api.github.com/repos/gtsteffaniak/filebrowser/releases?per_page=1" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.[0].tag_name')
+set -euo pipefail
+channel=${1:-main}
+
+# gtsteffaniak/filebrowser publishes preview/beta tags as GitHub releases, and
+# some preview releases are not flagged as prerelease by upstream. The stable
+# channel must not follow those; only use tags that are explicitly stable-ish.
+curl_args=(-fsSL "https://api.github.com/repos/gtsteffaniak/filebrowser/releases?per_page=100")
+if [[ -n "${TOKEN:-}" ]]; then
+    curl_args+=(--header "Authorization: Bearer ${TOKEN}")
+fi
+version=$(curl "${curl_args[@]}"   | jq --raw-output '[.[] | select(.draft == false) | select(.prerelease == false) | select(.tag_name | test("(?i)(preview|alpha|beta|rc)") | not)][0].tag_name')
+
+if [[ -z "${version}" || "${version}" == "null" ]]; then
+    echo "Unable to resolve a stable filebrowser release" >&2
+    exit 1
+fi
+
 printf "%s" "${version}"


### PR DESCRIPTION
## Summary
- filter Filebrowser upstream release lookup to stable-ish tags only
- skip draft/prerelease releases and tags containing preview/beta/alpha/rc
- fail loudly if no stable release resolves

## Verification
- `bash -n apps/filebrowser/ci/latest.sh`
- `./.github/scripts/upstream.sh filebrowser main` → `v1.5.0-stable`

## Context
The latest upstream GitHub release is currently `v2.0.0-preview-3`, but upstream marks it `prerelease=false`, so `releases?per_page=1` made the stable `main` channel attempt to build a preview.
