### PR TITLE
fix(ci): make Socket.dev report-only until org policy is tuned

### DIFF
--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -325,10 +325,17 @@ jobs:
             rc=1
           fi
 
-          # --- Socket.dev: behavioral supply-chain gate ---
+          # --- Socket.dev: behavioral supply-chain scan (report-only for now) ---
+          # `socket ci` fails on the org's FULL security policy, which on a fresh
+          # account gates on non-malware alerts (CVEs, obfuscatedFile) and can
+          # block legitimate builds. Keep it REPORT-ONLY (uploads the scan to the
+          # Socket dashboard, warns) until the org policy is tuned to block only
+          # malware. The build gate here is OSV's precise MAL-* check above; flip
+          # `socket ci` back to `|| rc=$?` once the policy warns on non-malware.
           if [ -n "${SOCKET_SECURITY_API_TOKEN:-}" ]; then
             echo "::group::Socket.dev"
-            ( cd "$dir" && npx -y socket ci ) || rc=$?
+            ( cd "$dir" && npx -y socket scan create . --org funky-penguin ) \
+              || echo "::warning::Socket scan reported issues (report-only; see Socket dashboard). Tune the org policy, then re-enable gating."
             echo "::endgroup::"
           else
             echo "::warning::SOCKET_SECURITY_API_TOKEN not set — skipping Socket.dev behavioral scan"


### PR DESCRIPTION
Follow-up to #773. `socket ci` gates on the org's *full* security policy, which on a fresh free account fails on non-malware alerts (CVEs, obfuscatedFile) — it blocked a legitimate debrid-vault build. Switch Socket to `socket scan create` (upload + report, **report-only**); the build's malware gate remains OSV's precise `MAL-*` check. Re-enable Socket gating (`|| rc=$?`) once the Socket org policy is tuned to block malware and warn on everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)