### PR TITLE
fix(ci): re-enable Socket.dev gating (token scope fixed)

### DIFF
--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -325,17 +325,15 @@ jobs:
             rc=1
           fi
 
-          # --- Socket.dev: behavioral supply-chain scan (report-only for now) ---
-          # `socket ci` fails on the org's FULL security policy, which on a fresh
-          # account gates on non-malware alerts (CVEs, obfuscatedFile) and can
-          # block legitimate builds. Keep it REPORT-ONLY (uploads the scan to the
-          # Socket dashboard, warns) until the org policy is tuned to block only
-          # malware. The build gate here is OSV's precise MAL-* check above; flip
-          # `socket ci` back to `|| rc=$?` once the policy warns on non-malware.
+          # --- Socket.dev: behavioral supply-chain gate ---
+          # The Socket org security policy is configured to BLOCK malware and warn
+          # on everything else, so `socket ci` fails the build only on malware
+          # (plus OSV's precise MAL-* check above). --org is required so the CLI
+          # runs non-interactively in CI; the token needs org security-policy read
+          # scope (otherwise socket ci 403s).
           if [ -n "${SOCKET_SECURITY_API_TOKEN:-}" ]; then
             echo "::group::Socket.dev"
-            ( cd "$dir" && npx -y socket scan create . --org funky-penguin ) \
-              || echo "::warning::Socket scan reported issues (report-only; see Socket dashboard). Tune the org policy, then re-enable gating."
+            ( cd "$dir" && npx -y socket ci --org funky-penguin ) || rc=$?
             echo "::endgroup::"
           else
             echo "::warning::SOCKET_SECURITY_API_TOKEN not set — skipping Socket.dev behavioral scan"


### PR DESCRIPTION
Reverts the temporary report-only mode from #774. The Socket API token now has org security-policy read scope, so `socket ci --org funky-penguin` reads the policy (configured to **block malware, warn on everything else**) and gates the build on malware. Verified locally: `socket ci` returns `healthy: true` on a clean run (the earlier 403 on `settings/security-policy` is resolved). OSV's `MAL-*` gate remains as the second layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)