### PR TITLE
feat(harbor): add nine Harbor backend services

### DIFF
--- a/apps/harbor-bugs/ci/latest.sh
+++ b/apps/harbor-bugs/ci/latest.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# harbor-bugs: one of the nine Harbor backend services.
+#
+# Source: https://github.com/harborstremio/harbor-hosted (PRIVATE), at
+# services/harbor-bugs/src. These images integrate with ElfHosted-internal
+# services (EMDB, ElfCache), so they are ElfHosted artifacts and are not
+# self-hostable.
+#
+# ZURG_GH_CREDS is the credential, and it is CONFIRMED to work here: the account
+# it belongs to holds write access on harborstremio/harbor-hosted, so the token
+# reads it despite the different org. The name records what it was created for,
+# not what it is scoped to. No Harbor-specific secret is needed. Every call below
+# returns empty without read access, which makes latest.sh emit an empty string,
+# which action-image-build.yaml deliberately treats as a hard build failure
+# rather than tagging a null image.
+#
+# WHAT THIS EMITS, and why it is a git ref rather than a bare semver: the value
+# printed here becomes both the --build-arg VERSION the Dockerfile checks out
+# AND the image tag. So it has to be resolvable by git and legal as a Docker
+# tag at the same time.
+#
+# PREFERRED: the newest per-component release-please tag. harbor-hosted's
+# release-please-config.json sets include-component-in-tag, include-v-in-tag and
+# tag-separator "-", so tags read harbor-bugs-v0.1.0. That form is a valid git ref
+# and a valid Docker tag, so it is emitted verbatim.
+#
+# FALLBACK: no harbor-bugs-v* tag exists yet, because the vendoring PR (#1) is
+# unmerged and release-please has never run against this repo. So the fallback
+# is the SHORT SHA of the vendoring branch head. Two more obvious fallbacks were
+# rejected:
+#
+#   * the branch name feat/vendored-services-and-deployment contains a SLASH,
+#     and this value is interpolated straight into the image tag, where a slash
+#     is illegal. The build would clone fine and then fail on push.
+#   * main does not yet contain services/ at all, so a build from main resolves
+#     to a real ref and then fails at the first COPY.
+#
+# A short sha is slash-free, legal as a tag, resolvable by the `git checkout` in
+# the Dockerfile, and it moves when the branch moves, so a new commit triggers a
+# rebuild on the next scheduled run. Same rationale as apps/docs-internal.
+#
+# main's short sha is the last resort, so that this keeps working after PR #1
+# merges and before the first release-please run.
+set -uo pipefail
+
+repo="harborstremio/harbor-hosted"
+component="harbor-bugs"
+branch="feat/vendored-services-and-deployment"
+auth_header="Authorization: Bearer ${ZURG_GH_CREDS}"
+
+# Newest harbor-bugs-v* tag. Sorted by version rather than trusting the API's
+# ordering, and filtered to x.y.z so a stray tag cannot win.
+version="$(
+  curl -fsSL -H "${auth_header}" \
+    "https://api.github.com/repos/${repo}/tags?per_page=100" \
+  | jq -r --arg c "${component}-v" '.[].name | select(startswith($c))' \
+  | sed "s/^${component}-v//" \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | tail -n1 \
+  | sed "s/^/${component}-v/"
+)"
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/${branch}" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/main" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+printf '%s' "${version}"

--- a/apps/harbor-bugs/metadata.json
+++ b/apps/harbor-bugs/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "harbor-bugs",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}

--- a/apps/harbor-community-sync/ci/latest.sh
+++ b/apps/harbor-community-sync/ci/latest.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# harbor-community-sync: one of the nine Harbor backend services.
+#
+# Source: https://github.com/harborstremio/harbor-hosted (PRIVATE), at
+# services/harbor-community-sync/src. These images integrate with ElfHosted-internal
+# services (EMDB, ElfCache), so they are ElfHosted artifacts and are not
+# self-hostable.
+#
+# ZURG_GH_CREDS is the credential, and it is CONFIRMED to work here: the account
+# it belongs to holds write access on harborstremio/harbor-hosted, so the token
+# reads it despite the different org. The name records what it was created for,
+# not what it is scoped to. No Harbor-specific secret is needed. Every call below
+# returns empty without read access, which makes latest.sh emit an empty string,
+# which action-image-build.yaml deliberately treats as a hard build failure
+# rather than tagging a null image.
+#
+# WHAT THIS EMITS, and why it is a git ref rather than a bare semver: the value
+# printed here becomes both the --build-arg VERSION the Dockerfile checks out
+# AND the image tag. So it has to be resolvable by git and legal as a Docker
+# tag at the same time.
+#
+# PREFERRED: the newest per-component release-please tag. harbor-hosted's
+# release-please-config.json sets include-component-in-tag, include-v-in-tag and
+# tag-separator "-", so tags read harbor-community-sync-v0.1.0. That form is a valid git ref
+# and a valid Docker tag, so it is emitted verbatim.
+#
+# FALLBACK: no harbor-community-sync-v* tag exists yet, because the vendoring PR (#1) is
+# unmerged and release-please has never run against this repo. So the fallback
+# is the SHORT SHA of the vendoring branch head. Two more obvious fallbacks were
+# rejected:
+#
+#   * the branch name feat/vendored-services-and-deployment contains a SLASH,
+#     and this value is interpolated straight into the image tag, where a slash
+#     is illegal. The build would clone fine and then fail on push.
+#   * main does not yet contain services/ at all, so a build from main resolves
+#     to a real ref and then fails at the first COPY.
+#
+# A short sha is slash-free, legal as a tag, resolvable by the `git checkout` in
+# the Dockerfile, and it moves when the branch moves, so a new commit triggers a
+# rebuild on the next scheduled run. Same rationale as apps/docs-internal.
+#
+# main's short sha is the last resort, so that this keeps working after PR #1
+# merges and before the first release-please run.
+set -uo pipefail
+
+repo="harborstremio/harbor-hosted"
+component="harbor-community-sync"
+branch="feat/vendored-services-and-deployment"
+auth_header="Authorization: Bearer ${ZURG_GH_CREDS}"
+
+# Newest harbor-community-sync-v* tag. Sorted by version rather than trusting the API's
+# ordering, and filtered to x.y.z so a stray tag cannot win.
+version="$(
+  curl -fsSL -H "${auth_header}" \
+    "https://api.github.com/repos/${repo}/tags?per_page=100" \
+  | jq -r --arg c "${component}-v" '.[].name | select(startswith($c))' \
+  | sed "s/^${component}-v//" \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | tail -n1 \
+  | sed "s/^/${component}-v/"
+)"
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/${branch}" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/main" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+printf '%s' "${version}"

--- a/apps/harbor-community-sync/metadata.json
+++ b/apps/harbor-community-sync/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "harbor-community-sync",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}

--- a/apps/harbor-imdb/ci/latest.sh
+++ b/apps/harbor-imdb/ci/latest.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# harbor-imdb: one of the nine Harbor backend services.
+#
+# Source: https://github.com/harborstremio/harbor-hosted (PRIVATE), at
+# services/harbor-imdb/src. These images integrate with ElfHosted-internal
+# services (EMDB, ElfCache), so they are ElfHosted artifacts and are not
+# self-hostable.
+#
+# ZURG_GH_CREDS is the credential, and it is CONFIRMED to work here: the account
+# it belongs to holds write access on harborstremio/harbor-hosted, so the token
+# reads it despite the different org. The name records what it was created for,
+# not what it is scoped to. No Harbor-specific secret is needed. Every call below
+# returns empty without read access, which makes latest.sh emit an empty string,
+# which action-image-build.yaml deliberately treats as a hard build failure
+# rather than tagging a null image.
+#
+# WHAT THIS EMITS, and why it is a git ref rather than a bare semver: the value
+# printed here becomes both the --build-arg VERSION the Dockerfile checks out
+# AND the image tag. So it has to be resolvable by git and legal as a Docker
+# tag at the same time.
+#
+# PREFERRED: the newest per-component release-please tag. harbor-hosted's
+# release-please-config.json sets include-component-in-tag, include-v-in-tag and
+# tag-separator "-", so tags read harbor-imdb-v0.1.0. That form is a valid git ref
+# and a valid Docker tag, so it is emitted verbatim.
+#
+# FALLBACK: no harbor-imdb-v* tag exists yet, because the vendoring PR (#1) is
+# unmerged and release-please has never run against this repo. So the fallback
+# is the SHORT SHA of the vendoring branch head. Two more obvious fallbacks were
+# rejected:
+#
+#   * the branch name feat/vendored-services-and-deployment contains a SLASH,
+#     and this value is interpolated straight into the image tag, where a slash
+#     is illegal. The build would clone fine and then fail on push.
+#   * main does not yet contain services/ at all, so a build from main resolves
+#     to a real ref and then fails at the first COPY.
+#
+# A short sha is slash-free, legal as a tag, resolvable by the `git checkout` in
+# the Dockerfile, and it moves when the branch moves, so a new commit triggers a
+# rebuild on the next scheduled run. Same rationale as apps/docs-internal.
+#
+# main's short sha is the last resort, so that this keeps working after PR #1
+# merges and before the first release-please run.
+set -uo pipefail
+
+repo="harborstremio/harbor-hosted"
+component="harbor-imdb"
+branch="feat/vendored-services-and-deployment"
+auth_header="Authorization: Bearer ${ZURG_GH_CREDS}"
+
+# Newest harbor-imdb-v* tag. Sorted by version rather than trusting the API's
+# ordering, and filtered to x.y.z so a stray tag cannot win.
+version="$(
+  curl -fsSL -H "${auth_header}" \
+    "https://api.github.com/repos/${repo}/tags?per_page=100" \
+  | jq -r --arg c "${component}-v" '.[].name | select(startswith($c))' \
+  | sed "s/^${component}-v//" \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | tail -n1 \
+  | sed "s/^/${component}-v/"
+)"
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/${branch}" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/main" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+printf '%s' "${version}"

--- a/apps/harbor-imdb/metadata.json
+++ b/apps/harbor-imdb/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "harbor-imdb",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}

--- a/apps/harbor-mal/ci/latest.sh
+++ b/apps/harbor-mal/ci/latest.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# harbor-mal: one of the nine Harbor backend services.
+#
+# Source: https://github.com/harborstremio/harbor-hosted (PRIVATE), at
+# services/harbor-mal/src. These images integrate with ElfHosted-internal
+# services (EMDB, ElfCache), so they are ElfHosted artifacts and are not
+# self-hostable.
+#
+# ZURG_GH_CREDS is the credential, and it is CONFIRMED to work here: the account
+# it belongs to holds write access on harborstremio/harbor-hosted, so the token
+# reads it despite the different org. The name records what it was created for,
+# not what it is scoped to. No Harbor-specific secret is needed. Every call below
+# returns empty without read access, which makes latest.sh emit an empty string,
+# which action-image-build.yaml deliberately treats as a hard build failure
+# rather than tagging a null image.
+#
+# WHAT THIS EMITS, and why it is a git ref rather than a bare semver: the value
+# printed here becomes both the --build-arg VERSION the Dockerfile checks out
+# AND the image tag. So it has to be resolvable by git and legal as a Docker
+# tag at the same time.
+#
+# PREFERRED: the newest per-component release-please tag. harbor-hosted's
+# release-please-config.json sets include-component-in-tag, include-v-in-tag and
+# tag-separator "-", so tags read harbor-mal-v0.1.0. That form is a valid git ref
+# and a valid Docker tag, so it is emitted verbatim.
+#
+# FALLBACK: no harbor-mal-v* tag exists yet, because the vendoring PR (#1) is
+# unmerged and release-please has never run against this repo. So the fallback
+# is the SHORT SHA of the vendoring branch head. Two more obvious fallbacks were
+# rejected:
+#
+#   * the branch name feat/vendored-services-and-deployment contains a SLASH,
+#     and this value is interpolated straight into the image tag, where a slash
+#     is illegal. The build would clone fine and then fail on push.
+#   * main does not yet contain services/ at all, so a build from main resolves
+#     to a real ref and then fails at the first COPY.
+#
+# A short sha is slash-free, legal as a tag, resolvable by the `git checkout` in
+# the Dockerfile, and it moves when the branch moves, so a new commit triggers a
+# rebuild on the next scheduled run. Same rationale as apps/docs-internal.
+#
+# main's short sha is the last resort, so that this keeps working after PR #1
+# merges and before the first release-please run.
+set -uo pipefail
+
+repo="harborstremio/harbor-hosted"
+component="harbor-mal"
+branch="feat/vendored-services-and-deployment"
+auth_header="Authorization: Bearer ${ZURG_GH_CREDS}"
+
+# Newest harbor-mal-v* tag. Sorted by version rather than trusting the API's
+# ordering, and filtered to x.y.z so a stray tag cannot win.
+version="$(
+  curl -fsSL -H "${auth_header}" \
+    "https://api.github.com/repos/${repo}/tags?per_page=100" \
+  | jq -r --arg c "${component}-v" '.[].name | select(startswith($c))' \
+  | sed "s/^${component}-v//" \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | tail -n1 \
+  | sed "s/^/${component}-v/"
+)"
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/${branch}" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/main" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+printf '%s' "${version}"

--- a/apps/harbor-mal/metadata.json
+++ b/apps/harbor-mal/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "harbor-mal",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "web"
+      }
+    }
+  ]
+}

--- a/apps/harbor-manga-sources/ci/latest.sh
+++ b/apps/harbor-manga-sources/ci/latest.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# harbor-manga-sources: one of the nine Harbor backend services.
+#
+# Source: https://github.com/harborstremio/harbor-hosted (PRIVATE), at
+# services/harbor-manga-sources/src. These images integrate with ElfHosted-internal
+# services (EMDB, ElfCache), so they are ElfHosted artifacts and are not
+# self-hostable.
+#
+# ZURG_GH_CREDS is the credential, and it is CONFIRMED to work here: the account
+# it belongs to holds write access on harborstremio/harbor-hosted, so the token
+# reads it despite the different org. The name records what it was created for,
+# not what it is scoped to. No Harbor-specific secret is needed. Every call below
+# returns empty without read access, which makes latest.sh emit an empty string,
+# which action-image-build.yaml deliberately treats as a hard build failure
+# rather than tagging a null image.
+#
+# WHAT THIS EMITS, and why it is a git ref rather than a bare semver: the value
+# printed here becomes both the --build-arg VERSION the Dockerfile checks out
+# AND the image tag. So it has to be resolvable by git and legal as a Docker
+# tag at the same time.
+#
+# PREFERRED: the newest per-component release-please tag. harbor-hosted's
+# release-please-config.json sets include-component-in-tag, include-v-in-tag and
+# tag-separator "-", so tags read harbor-manga-sources-v0.1.0. That form is a valid git ref
+# and a valid Docker tag, so it is emitted verbatim.
+#
+# FALLBACK: no harbor-manga-sources-v* tag exists yet, because the vendoring PR (#1) is
+# unmerged and release-please has never run against this repo. So the fallback
+# is the SHORT SHA of the vendoring branch head. Two more obvious fallbacks were
+# rejected:
+#
+#   * the branch name feat/vendored-services-and-deployment contains a SLASH,
+#     and this value is interpolated straight into the image tag, where a slash
+#     is illegal. The build would clone fine and then fail on push.
+#   * main does not yet contain services/ at all, so a build from main resolves
+#     to a real ref and then fails at the first COPY.
+#
+# A short sha is slash-free, legal as a tag, resolvable by the `git checkout` in
+# the Dockerfile, and it moves when the branch moves, so a new commit triggers a
+# rebuild on the next scheduled run. Same rationale as apps/docs-internal.
+#
+# main's short sha is the last resort, so that this keeps working after PR #1
+# merges and before the first release-please run.
+set -uo pipefail
+
+repo="harborstremio/harbor-hosted"
+component="harbor-manga-sources"
+branch="feat/vendored-services-and-deployment"
+auth_header="Authorization: Bearer ${ZURG_GH_CREDS}"
+
+# Newest harbor-manga-sources-v* tag. Sorted by version rather than trusting the API's
+# ordering, and filtered to x.y.z so a stray tag cannot win.
+version="$(
+  curl -fsSL -H "${auth_header}" \
+    "https://api.github.com/repos/${repo}/tags?per_page=100" \
+  | jq -r --arg c "${component}-v" '.[].name | select(startswith($c))' \
+  | sed "s/^${component}-v//" \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | tail -n1 \
+  | sed "s/^/${component}-v/"
+)"
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/${branch}" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/main" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+printf '%s' "${version}"

--- a/apps/harbor-manga-sources/metadata.json
+++ b/apps/harbor-manga-sources/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "harbor-manga-sources",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}

--- a/apps/harbor-simkl/ci/latest.sh
+++ b/apps/harbor-simkl/ci/latest.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# harbor-simkl: one of the nine Harbor backend services.
+#
+# Source: https://github.com/harborstremio/harbor-hosted (PRIVATE), at
+# services/harbor-simkl/src. These images integrate with ElfHosted-internal
+# services (EMDB, ElfCache), so they are ElfHosted artifacts and are not
+# self-hostable.
+#
+# ZURG_GH_CREDS is the credential, and it is CONFIRMED to work here: the account
+# it belongs to holds write access on harborstremio/harbor-hosted, so the token
+# reads it despite the different org. The name records what it was created for,
+# not what it is scoped to. No Harbor-specific secret is needed. Every call below
+# returns empty without read access, which makes latest.sh emit an empty string,
+# which action-image-build.yaml deliberately treats as a hard build failure
+# rather than tagging a null image.
+#
+# WHAT THIS EMITS, and why it is a git ref rather than a bare semver: the value
+# printed here becomes both the --build-arg VERSION the Dockerfile checks out
+# AND the image tag. So it has to be resolvable by git and legal as a Docker
+# tag at the same time.
+#
+# PREFERRED: the newest per-component release-please tag. harbor-hosted's
+# release-please-config.json sets include-component-in-tag, include-v-in-tag and
+# tag-separator "-", so tags read harbor-simkl-v0.1.0. That form is a valid git ref
+# and a valid Docker tag, so it is emitted verbatim.
+#
+# FALLBACK: no harbor-simkl-v* tag exists yet, because the vendoring PR (#1) is
+# unmerged and release-please has never run against this repo. So the fallback
+# is the SHORT SHA of the vendoring branch head. Two more obvious fallbacks were
+# rejected:
+#
+#   * the branch name feat/vendored-services-and-deployment contains a SLASH,
+#     and this value is interpolated straight into the image tag, where a slash
+#     is illegal. The build would clone fine and then fail on push.
+#   * main does not yet contain services/ at all, so a build from main resolves
+#     to a real ref and then fails at the first COPY.
+#
+# A short sha is slash-free, legal as a tag, resolvable by the `git checkout` in
+# the Dockerfile, and it moves when the branch moves, so a new commit triggers a
+# rebuild on the next scheduled run. Same rationale as apps/docs-internal.
+#
+# main's short sha is the last resort, so that this keeps working after PR #1
+# merges and before the first release-please run.
+set -uo pipefail
+
+repo="harborstremio/harbor-hosted"
+component="harbor-simkl"
+branch="feat/vendored-services-and-deployment"
+auth_header="Authorization: Bearer ${ZURG_GH_CREDS}"
+
+# Newest harbor-simkl-v* tag. Sorted by version rather than trusting the API's
+# ordering, and filtered to x.y.z so a stray tag cannot win.
+version="$(
+  curl -fsSL -H "${auth_header}" \
+    "https://api.github.com/repos/${repo}/tags?per_page=100" \
+  | jq -r --arg c "${component}-v" '.[].name | select(startswith($c))' \
+  | sed "s/^${component}-v//" \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | tail -n1 \
+  | sed "s/^/${component}-v/"
+)"
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/${branch}" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/main" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+printf '%s' "${version}"

--- a/apps/harbor-simkl/metadata.json
+++ b/apps/harbor-simkl/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "harbor-simkl",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}

--- a/apps/harbor-themes/ci/latest.sh
+++ b/apps/harbor-themes/ci/latest.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# harbor-themes: one of the nine Harbor backend services.
+#
+# Source: https://github.com/harborstremio/harbor-hosted (PRIVATE), at
+# services/harbor-themes/src. These images integrate with ElfHosted-internal
+# services (EMDB, ElfCache), so they are ElfHosted artifacts and are not
+# self-hostable.
+#
+# ZURG_GH_CREDS is the credential, and it is CONFIRMED to work here: the account
+# it belongs to holds write access on harborstremio/harbor-hosted, so the token
+# reads it despite the different org. The name records what it was created for,
+# not what it is scoped to. No Harbor-specific secret is needed. Every call below
+# returns empty without read access, which makes latest.sh emit an empty string,
+# which action-image-build.yaml deliberately treats as a hard build failure
+# rather than tagging a null image.
+#
+# WHAT THIS EMITS, and why it is a git ref rather than a bare semver: the value
+# printed here becomes both the --build-arg VERSION the Dockerfile checks out
+# AND the image tag. So it has to be resolvable by git and legal as a Docker
+# tag at the same time.
+#
+# PREFERRED: the newest per-component release-please tag. harbor-hosted's
+# release-please-config.json sets include-component-in-tag, include-v-in-tag and
+# tag-separator "-", so tags read harbor-themes-v0.1.0. That form is a valid git ref
+# and a valid Docker tag, so it is emitted verbatim.
+#
+# FALLBACK: no harbor-themes-v* tag exists yet, because the vendoring PR (#1) is
+# unmerged and release-please has never run against this repo. So the fallback
+# is the SHORT SHA of the vendoring branch head. Two more obvious fallbacks were
+# rejected:
+#
+#   * the branch name feat/vendored-services-and-deployment contains a SLASH,
+#     and this value is interpolated straight into the image tag, where a slash
+#     is illegal. The build would clone fine and then fail on push.
+#   * main does not yet contain services/ at all, so a build from main resolves
+#     to a real ref and then fails at the first COPY.
+#
+# A short sha is slash-free, legal as a tag, resolvable by the `git checkout` in
+# the Dockerfile, and it moves when the branch moves, so a new commit triggers a
+# rebuild on the next scheduled run. Same rationale as apps/docs-internal.
+#
+# main's short sha is the last resort, so that this keeps working after PR #1
+# merges and before the first release-please run.
+set -uo pipefail
+
+repo="harborstremio/harbor-hosted"
+component="harbor-themes"
+branch="feat/vendored-services-and-deployment"
+auth_header="Authorization: Bearer ${ZURG_GH_CREDS}"
+
+# Newest harbor-themes-v* tag. Sorted by version rather than trusting the API's
+# ordering, and filtered to x.y.z so a stray tag cannot win.
+version="$(
+  curl -fsSL -H "${auth_header}" \
+    "https://api.github.com/repos/${repo}/tags?per_page=100" \
+  | jq -r --arg c "${component}-v" '.[].name | select(startswith($c))' \
+  | sed "s/^${component}-v//" \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | tail -n1 \
+  | sed "s/^/${component}-v/"
+)"
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/${branch}" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/main" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+printf '%s' "${version}"

--- a/apps/harbor-themes/metadata.json
+++ b/apps/harbor-themes/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "harbor-themes",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}

--- a/apps/harbor-trakt/ci/latest.sh
+++ b/apps/harbor-trakt/ci/latest.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# harbor-trakt: one of the nine Harbor backend services.
+#
+# Source: https://github.com/harborstremio/harbor-hosted (PRIVATE), at
+# services/harbor-trakt/src. These images integrate with ElfHosted-internal
+# services (EMDB, ElfCache), so they are ElfHosted artifacts and are not
+# self-hostable.
+#
+# ZURG_GH_CREDS is the credential, and it is CONFIRMED to work here: the account
+# it belongs to holds write access on harborstremio/harbor-hosted, so the token
+# reads it despite the different org. The name records what it was created for,
+# not what it is scoped to. No Harbor-specific secret is needed. Every call below
+# returns empty without read access, which makes latest.sh emit an empty string,
+# which action-image-build.yaml deliberately treats as a hard build failure
+# rather than tagging a null image.
+#
+# WHAT THIS EMITS, and why it is a git ref rather than a bare semver: the value
+# printed here becomes both the --build-arg VERSION the Dockerfile checks out
+# AND the image tag. So it has to be resolvable by git and legal as a Docker
+# tag at the same time.
+#
+# PREFERRED: the newest per-component release-please tag. harbor-hosted's
+# release-please-config.json sets include-component-in-tag, include-v-in-tag and
+# tag-separator "-", so tags read harbor-trakt-v0.1.0. That form is a valid git ref
+# and a valid Docker tag, so it is emitted verbatim.
+#
+# FALLBACK: no harbor-trakt-v* tag exists yet, because the vendoring PR (#1) is
+# unmerged and release-please has never run against this repo. So the fallback
+# is the SHORT SHA of the vendoring branch head. Two more obvious fallbacks were
+# rejected:
+#
+#   * the branch name feat/vendored-services-and-deployment contains a SLASH,
+#     and this value is interpolated straight into the image tag, where a slash
+#     is illegal. The build would clone fine and then fail on push.
+#   * main does not yet contain services/ at all, so a build from main resolves
+#     to a real ref and then fails at the first COPY.
+#
+# A short sha is slash-free, legal as a tag, resolvable by the `git checkout` in
+# the Dockerfile, and it moves when the branch moves, so a new commit triggers a
+# rebuild on the next scheduled run. Same rationale as apps/docs-internal.
+#
+# main's short sha is the last resort, so that this keeps working after PR #1
+# merges and before the first release-please run.
+set -uo pipefail
+
+repo="harborstremio/harbor-hosted"
+component="harbor-trakt"
+branch="feat/vendored-services-and-deployment"
+auth_header="Authorization: Bearer ${ZURG_GH_CREDS}"
+
+# Newest harbor-trakt-v* tag. Sorted by version rather than trusting the API's
+# ordering, and filtered to x.y.z so a stray tag cannot win.
+version="$(
+  curl -fsSL -H "${auth_header}" \
+    "https://api.github.com/repos/${repo}/tags?per_page=100" \
+  | jq -r --arg c "${component}-v" '.[].name | select(startswith($c))' \
+  | sed "s/^${component}-v//" \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | tail -n1 \
+  | sed "s/^/${component}-v/"
+)"
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/${branch}" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/main" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+printf '%s' "${version}"

--- a/apps/harbor-trakt/metadata.json
+++ b/apps/harbor-trakt/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "harbor-trakt",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "web"
+      }
+    }
+  ]
+}

--- a/apps/harbor-tvdb/ci/latest.sh
+++ b/apps/harbor-tvdb/ci/latest.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# harbor-tvdb: one of the nine Harbor backend services.
+#
+# Source: https://github.com/harborstremio/harbor-hosted (PRIVATE), at
+# services/harbor-tvdb/src. These images integrate with ElfHosted-internal
+# services (EMDB, ElfCache), so they are ElfHosted artifacts and are not
+# self-hostable.
+#
+# ZURG_GH_CREDS is the credential, and it is CONFIRMED to work here: the account
+# it belongs to holds write access on harborstremio/harbor-hosted, so the token
+# reads it despite the different org. The name records what it was created for,
+# not what it is scoped to. No Harbor-specific secret is needed. Every call below
+# returns empty without read access, which makes latest.sh emit an empty string,
+# which action-image-build.yaml deliberately treats as a hard build failure
+# rather than tagging a null image.
+#
+# WHAT THIS EMITS, and why it is a git ref rather than a bare semver: the value
+# printed here becomes both the --build-arg VERSION the Dockerfile checks out
+# AND the image tag. So it has to be resolvable by git and legal as a Docker
+# tag at the same time.
+#
+# PREFERRED: the newest per-component release-please tag. harbor-hosted's
+# release-please-config.json sets include-component-in-tag, include-v-in-tag and
+# tag-separator "-", so tags read harbor-tvdb-v0.1.0. That form is a valid git ref
+# and a valid Docker tag, so it is emitted verbatim.
+#
+# FALLBACK: no harbor-tvdb-v* tag exists yet, because the vendoring PR (#1) is
+# unmerged and release-please has never run against this repo. So the fallback
+# is the SHORT SHA of the vendoring branch head. Two more obvious fallbacks were
+# rejected:
+#
+#   * the branch name feat/vendored-services-and-deployment contains a SLASH,
+#     and this value is interpolated straight into the image tag, where a slash
+#     is illegal. The build would clone fine and then fail on push.
+#   * main does not yet contain services/ at all, so a build from main resolves
+#     to a real ref and then fails at the first COPY.
+#
+# A short sha is slash-free, legal as a tag, resolvable by the `git checkout` in
+# the Dockerfile, and it moves when the branch moves, so a new commit triggers a
+# rebuild on the next scheduled run. Same rationale as apps/docs-internal.
+#
+# main's short sha is the last resort, so that this keeps working after PR #1
+# merges and before the first release-please run.
+set -uo pipefail
+
+repo="harborstremio/harbor-hosted"
+component="harbor-tvdb"
+branch="feat/vendored-services-and-deployment"
+auth_header="Authorization: Bearer ${ZURG_GH_CREDS}"
+
+# Newest harbor-tvdb-v* tag. Sorted by version rather than trusting the API's
+# ordering, and filtered to x.y.z so a stray tag cannot win.
+version="$(
+  curl -fsSL -H "${auth_header}" \
+    "https://api.github.com/repos/${repo}/tags?per_page=100" \
+  | jq -r --arg c "${component}-v" '.[].name | select(startswith($c))' \
+  | sed "s/^${component}-v//" \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | tail -n1 \
+  | sed "s/^/${component}-v/"
+)"
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/${branch}" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+if [[ -z "${version}" ]]; then
+  version="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/commits/main" \
+    | jq -r '.sha[0:7] // empty'
+  )"
+fi
+
+printf '%s' "${version}"

--- a/apps/harbor-tvdb/metadata.json
+++ b/apps/harbor-tvdb/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "harbor-tvdb",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds Harbor's nine backend services to the standard build pipeline. Paired with `elfhosted/containers-private#<n>` on the matching branch name, which holds the Dockerfiles and goss files.

## Context

ElfHosted is taking over Harbor's entire server-side estate. `harbor.site` is being shut down and `harbor.elfhosted.com` becomes the only instance. These images integrate with elf-internal services (emdb, zilean), so they are ElfHosted artifacts and are **deliberately not self-hostable**.

Full analysis, the migration plan and the decisions of record live in `harborstremio/harbor-hosted` (private), PR #1.

## Where the source comes from

`harborstremio/harbor-hosted`, at `services/<service>/src/`. It was vendored there from the retiring VPS with per-tree provenance (`copied_at`, `copied_sha256`) recorded in `services/sources.yaml`.

The Dockerfiles clone it in an alpine `cloner` stage, exactly the shape zurg uses. **One authoritative copy, nothing duplicated into `containers-private`** — two copies is the drift failure that already bit us with `pub.harbor.site`, where five of nine files had diverged and `RELAY_VERSION` was a version behind with nobody noticing.

## Credentials: nothing to provision

`ZURG_GH_CREDS` works for `harborstremio/harbor-hosted`. The account it belongs to holds write access there, so the token reads the repo despite the different org. The secret's name records what it was created for, not what it is scoped to.

It is also already exported by `.github/scripts/upstream.sh`, so `ci/latest.sh` receives it with no plumbing at all, and `action-image-build.yaml` needs **no change** (an earlier revision of this branch added a `HARBOR_HOSTED_GH_CREDS` and wired it into four places; both are reverted, and that file is byte-identical to `main` again).

No registry credential either: GHCR login here is plain `secrets.GITHUB_TOKEN`, because the repo owner matches the registry namespace.


## Please read this before trusting a green goss run

goss runs **inside** the container, so `http://localhost:PORT` succeeds even though **eight of these nine services bind the hardcoded literal `127.0.0.1`** and cannot be reached from outside the container. Verified by measurement.

So in-container testing **structurally cannot catch the biggest defect in these images.** It survived a full read-through of the source and only surfaced when someone curled from the host. The fix is one line per service upstream, tracked as `upstream/08-bind-host.md` in harbor-hosted. `harbor-bugs` is the exception; its bind host is already an env var.

Until that lands, these images build and run but nothing can route to eight of them.

## Details worth knowing

- **`platforms` pinned to `linux/amd64`** on all nine. They were built and run successfully on 2026-07-30, but on arm64, so every native prebuild (`sharp`, `better-sqlite3`) resolved without exercising the node-gyp fallback. amd64 is unverified.
- **goss enabled on seven of nine.** Disabled on `harbor-mal` and `harbor-trakt`, which exit 1 without their OAuth client secrets, so there would be no process to test.
- **Health paths are read from the route definitions, not guessed.** Two are not `/health`: `harbor-bugs` is `/v1/health`, `harbor-themes` is `${HARBOR_THEMES_BASE}/health`. Three services have no health route at all. A liveness probe on the wrong path would restart-loop the AniList token exchange for every Harbor client including desktop.
- **`ci/latest.sh`** queries `harborstremio/harbor-hosted` for the newest `<app>-v*` tag, which is what release-please cuts there. No such tags exist yet because harbor-hosted PR #1 is unmerged, so the scripts fall back to a branch. That fallback is temporary and should be revisited once release-please has run.
- **`harbor-imdb` builds its own dataset.** `ingest.js` runs at build time to produce a ~120 MB `imdb.db`, because the dataset cannot live in git. 63 MB downloaded, output within 0.3% of the host's database. The dataset stays baked, which is what lets the service scale to N replicas.

## State

Nothing here has been built by CI. The Dockerfiles were ported from ones that were built and run locally on 2026-07-30, where five of nine turned out to have real bugs and two built cleanly then failed at runtime, so the working logic is carried across rather than re-derived. Details in the paired PR's commit message.

