### PR TITLE
feat(harbor-site): build metadata for the Harbor apex site

### DIFF
--- a/apps/harbor-site/ci/latest.sh
+++ b/apps/harbor-site/ci/latest.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# harbor-site: nginx serving Harbor's apex marketing site out of Backblaze B2.
+#
+# THERE IS NOTHING UPSTREAM TO RESOLVE. Every other harbor-* app here reads a
+# release tag out of harborstremio/harbor-hosted; this one has no source
+# repository at all. The entire image is the nginx configuration and the njs
+# signing module in containers-private/apps/harbor-site/, and the site content it
+# serves is not in the image -- it is 114 MB of objects in the elfhosted-harbor
+# bucket under ${HARBOR_S3_PREFIX}site/, which is why a content change needs no
+# build.
+#
+# SO THIS VERSION IS HAND-MAINTAINED, AND IT IS THE ONLY LEVER THAT MOVES THE
+# IMAGE. Change anything in containers-private/apps/harbor-site/ and bump it in
+# the same pull request. Skipping the bump does not fail: it produces new image
+# contents under a tag that already exists, so the HelmRelease has nothing to
+# change, Flux has nothing to reconcile, and imagePullPolicy IfNotPresent serves
+# the old layer even across a pod restart. That is the trap recorded in
+# harbor-hosted's HANDOVER.md §2, and here there is no tag to forget to cut --
+# only this line.
+#
+# The same pattern is used by apps/dante and apps/tinyproxy, for the same reason.
+#
+# CHANGELOG
+#   1.0.0  initial: apex site at /, /api/curated/ and /api/hero/ from B2
+set -uo pipefail
+
+printf '%s' "1.0.0"

--- a/apps/harbor-site/metadata.json
+++ b/apps/harbor-site/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "harbor-site",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Build metadata (`metadata.json` + `ci/latest.sh`) for `harbor-site`.

## Context

`harbor.elfhosted.com` currently serves the **backend metadata paths only** — the SPA player was deliberately unpublished, because it is the full Harbor player and will be gated behind a private subscription rather than offered publicly.

This adds `harbor-site`: a mirror of the current `harbor.site` marketing site at `/`, served from Backblaze B2.

## Verification

- **17 paths fetched through a real Traefik** in the CI cluster and sha256-compared byte-for-byte against live `harbor.site` — all match. Includes SPA 404 fallback, directory→index.html, a 3.7 MB mp4, and the two filenames that exercise the canonical-URI encoder.
- Ran against a throwaway Deployment on a hostname resolving nowhere, curled from inside the cluster, **deleted afterwards**.
- Three rounds of `codex-review`. Round 1 caught a P1 the testing had missed: `nginx -t` runs as root and leaves `/tmp/nginx.pid` root-owned, so UID 101 could not start under `dgoss` (which uses no tmpfs). That would have failed only the smoke test — a red run reading as a bad image.

## Known follow-up: the site is not static

A root crontab on the VPS regenerates `feed/hero-pool.json`, 220 files under `rank/`, and `feed/award-winners.json` — **222 of 1211 objects, every 6 hours**. A snapshot drifts within a day, so a sync mechanism is required. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)