### PR TITLE
fix(harbor-site): serve /updates/ on harbor.site instead of redirecting it

### DIFF
--- a/apps/harbor-site/Dockerfile
+++ b/apps/harbor-site/Dockerfile
@@ -31,6 +31,8 @@ RUN rm -f /etc/nginx/conf.d/default.conf
 COPY apps/harbor-site/nginx.conf                   /etc/nginx/nginx.conf
 COPY apps/harbor-site/harbor-site.conf             /etc/nginx/conf.d/harbor-site.conf
 COPY apps/harbor-site/harbor-origin.conf           /etc/nginx/snippets/harbor-origin.conf
+COPY apps/harbor-site/harbor-updates.conf          /etc/nginx/snippets/harbor-updates.conf
+COPY apps/harbor-site/harbor-notfound.conf         /etc/nginx/snippets/harbor-notfound.conf
 COPY apps/harbor-site/harbor-site.js               /etc/nginx/njs/harbor-site.js
 COPY apps/harbor-site/05-harbor-site-resolver.sh   /docker-entrypoint.d/05-harbor-site-resolver.sh
 
@@ -45,6 +47,8 @@ RUN chmod 0755 /docker-entrypoint.d/05-harbor-site-resolver.sh \
  && chmod 0644 /etc/nginx/nginx.conf \
                /etc/nginx/conf.d/harbor-site.conf \
                /etc/nginx/snippets/harbor-origin.conf \
+               /etc/nginx/snippets/harbor-updates.conf \
+               /etc/nginx/snippets/harbor-notfound.conf \
                /etc/nginx/njs/harbor-site.js \
                /usr/share/nginx/seo/robots.txt \
                /usr/share/nginx/seo/sitemap.xml

--- a/apps/harbor-site/ci/goss.yaml
+++ b/apps/harbor-site/ci/goss.yaml
@@ -71,6 +71,31 @@ http:
   # no Backblaze credentials -- which is also the property being asserted. If
   # either ever falls through to the origin it 500s here, and that is the signal
   # that the bucket's wrong copy is being served again.
+  # THE UPDATER PATH MUST NOT REDIRECT ON harbor.site. Every installed binary has
+  # https://harbor.site/updates/latest.json compiled in and cannot be repointed,
+  # so if this ever becomes a 3xx again, clients depend on their HTTP library
+  # following it -- and if it does not, they are unreachable forever.
+  #
+  # 500 is the expected status here, not a failure: there are no Backblaze
+  # credentials in CI, so the origin fetch throws. What is being asserted is that
+  # the request REACHED the origin rather than being answered with a redirect.
+  # 301/302/307/308 would all fail this check.
+  # NOTE THE TWO DIFFERENT SPELLINGS OF LOOPBACK BELOW. They are one host and one
+  # port; the difference exists only because goss keys http resources by URL, so
+  # writing the same URL twice would be a duplicate YAML key -- the second silently
+  # replacing the first, and the harbor.site case never running at all.
+  http://localhost:8080/updates/latest.json:
+    headers:
+      Host: harbor.site
+    status: 500
+    timeout: 10000
+
+  # The same path on the default host, which must behave identically. Both server
+  # blocks include the one snippet, and this pair is what proves it.
+  http://127.0.0.1:8080/updates/latest.json:
+    status: 500
+    timeout: 10000
+
   http://localhost:8080/robots.txt:
     status: 200
     timeout: 5000

--- a/apps/harbor-site/ci/latest.sh
+++ b/apps/harbor-site/ci/latest.sh
@@ -42,6 +42,11 @@
 #          the nine Disallow rules and ai-train=no that Cloudflare's managed
 #          robots.txt published for harbor.site -- a deliberate policy change,
 #          not an omission. See harbor-site.conf.
+#   1.2.0  serve /updates/ DIRECTLY on harbor.site instead of 308-ing it. Every
+#          installed binary has that URL compiled in and cannot be repointed, so
+#          a redirect the updater failed to follow would strand every client with
+#          no way to reach them. Both hostnames now include one shared snippet,
+#          so they cannot drift.
 set -uo pipefail
 
-printf '%s' "1.1.0"
+printf '%s' "1.2.0"

--- a/apps/harbor-site/harbor-notfound.conf
+++ b/apps/harbor-site/harbor-notfound.conf
@@ -1,0 +1,19 @@
+# A miss, expressed as our own 404 rather than B2's XML <Error> document --
+# which names the bucket and the key that was looked up.
+#
+# A snippet because harbor-updates.conf refers to @notfound and is included by
+# both server blocks, so both need this defined. It cannot simply live in one
+# of them: a named location is scoped to its server.
+
+location @notfound {
+    internal;
+    default_type text/plain;
+    # Empty for every path that is not cross-origin, and nginx emits nothing
+    # for an empty add_header. See the $harbor_cors_origin map.
+    add_header Access-Control-Allow-Origin $harbor_cors_origin always;
+    add_header Cache-Control "no-store" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    return 404 "404 Not Found\n";
+}

--- a/apps/harbor-site/harbor-site.conf
+++ b/apps/harbor-site/harbor-site.conf
@@ -11,13 +11,15 @@
 #   /api/curated/…   -> ${HARBOR_S3_PREFIX}site/curated/…  was /opt/harbor-curated
 #   /api/hero/…      -> ${HARBOR_S3_PREFIX}site/hero/…     was /opt/harbor-hero
 #
+#   /updates/…       -> ${HARBOR_S3_PREFIX}updates/…    was /var/www/harbor-apex
+#
 # NOT ported, on purpose:
-#   /updates/…  /download/…  the desktop release artifacts, ~8 GB. They change
-#                            with every Harbor release, so a copy of them is
-#                            stale the moment it lands and a stale
-#                            /updates/latest.json breaks auto-update for every
-#                            installed client. They need a publish pipeline, not
-#                            a route.
+#   /download/…              ~8 GB of release artifacts. Unlike /updates/, which
+#                            is small, versioned and load-bearing for every
+#                            installed client, nothing points at /download/
+#                            automatically -- so it 404s rather than being
+#                            published. Removing that 404 is a decision to
+#                            publish 8 GB, not a tidy-up.
 #   /feed/                   an ordinary directory inside the docroot; it is
 #                            already covered by `location /`, and its VPS block
 #                            only added CORS, which is re-added below.
@@ -131,12 +133,17 @@ js_set $harbor_sha  harbor.payloadHash nocache;
 # (a different host) and togetherRelayUrl is opt-in, so nothing should arrive here;
 # if anything does, a 404 is honest where a redirect would look like a broken relay.
 #
-# STILL TO VERIFY BEFORE DNS MOVES: the desktop updater. Every installed binary has
-# https://harbor.site/updates/latest.json compiled into it (tauri.conf.json) and
-# cannot be changed after the fact. Tauri v2's updater uses reqwest, which follows
-# redirects by default, so this very probably works -- but "very probably" is not
-# good enough for the one failure that cannot be undone. Test with a real signed
-# client against this host before the flip.
+# NOT REDIRECTED EITHER: /updates/. This used to be a 308 and used to carry a note
+# saying a signed client had to test it before the DNS flip. That test is no longer
+# needed, because the path is now SERVED here rather than redirected.
+#
+# The reasoning: every installed binary has https://harbor.site/updates/latest.json
+# compiled into it (tauri.conf.json) and cannot be changed after the fact. Tauri v2's
+# updater uses reqwest, which follows redirects by default, so a 308 very probably
+# worked -- but "very probably" is not good enough for the one failure that cannot be
+# undone, and a wrong answer strands every installed client with no channel left to
+# reach them through. Serving it directly removes the question instead of answering
+# it. Both hostnames include the same snippet, so they cannot drift.
 server {
     listen 8080;
     listen [::]:8080;
@@ -149,7 +156,19 @@ server {
     # for harbor.site.
 
     # Machine-called surfaces: method-preserving.
-    location ^~ /updates/    { return 308 https://harbor.elfhosted.com$request_uri; }
+    # /updates/ IS SERVED HERE, NOT REDIRECTED, and that is the one asymmetry in
+    # this block. Every installed binary has https://harbor.site/updates/latest.json
+    # compiled in via tauri.conf.json and cannot be repointed afterwards, so if a
+    # redirect were not followed there would be no channel left to reach those
+    # clients through. A 308 would very probably work -- reqwest follows redirects
+    # by default -- but "very probably" is the wrong standard for the single
+    # unrecoverable failure in this migration. Serving it directly removes the
+    # question instead of answering it.
+    #
+    # Identical to harbor.${dns_domain} by construction: same snippet, not a copy.
+    include /etc/nginx/snippets/harbor-notfound.conf;
+    include /etc/nginx/snippets/harbor-updates.conf;
+
     location ^~ /api/        { return 308 https://harbor.elfhosted.com$request_uri; }
     location ^~ /themes/api/ { return 308 https://harbor.elfhosted.com$request_uri; }
     location ^~ /v1/         { return 308 https://harbor.elfhosted.com$request_uri; }
@@ -270,35 +289,9 @@ server {
     #
     # Removing this block is a decision to publish 8 GB of release artifacts, not
     # a tidy-up.
-    # The channel manifest. EXACT match, so it beats the prefix location below.
-    #
-    # Cache-Control is no-store and Vary carries the channel header. Without the
-    # Vary an edge cache can hand a beta manifest to a stable client, which
-    # silently up- or downgrades every installed desktop app pointed at it --
-    # invisible until someone reports the wrong version.
-    location = /updates/latest.json {
-        set $harbor_key "updates/latest${harbor_chan}.json";
-        include /etc/nginx/snippets/harbor-origin.conf;
-        error_page 403 404 = @notfound;
-        add_header Cache-Control "no-store" always;
-        add_header Vary "X-Harbor-Channel" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Frame-Options "DENY" always;
-        add_header Referrer-Policy "no-referrer-when-downgrade" always;
-    }
-
-    # The artifacts: installers, .app.tar.gz, .dmg and their .sig files. Version
-    # is in the filename, so they are immutable and cache hard -- ~250 MB each,
-    # which is the whole reason for keeping them behind Cloudflare.
-    location ^~ /updates/ {
-        set $harbor_key "updates/$harbor_updates_path";
-        include /etc/nginx/snippets/harbor-origin.conf;
-        error_page 403 404 = @notfound;
-        add_header Cache-Control "public, max-age=2592000, immutable" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Frame-Options "DENY" always;
-        add_header Referrer-Policy "no-referrer-when-downgrade" always;
-    }
+    # Included, not inlined: harbor.site includes the very same file, so the two
+    # hostnames cannot drift. See harbor-updates.conf for why that matters.
+    include /etc/nginx/snippets/harbor-updates.conf;
 
     location ^~ /download {
         default_type text/plain;
@@ -400,18 +393,7 @@ server {
         add_header Referrer-Policy "no-referrer-when-downgrade" always;
     }
 
-    # A miss, expressed as our own 404 rather than B2's XML <Error> document --
-    # which names the bucket and the key that was looked up.
-    location @notfound {
-        internal;
-        default_type text/plain;
-        # Empty for every path that is not cross-origin, and nginx emits nothing
-        # for an empty add_header. See the $harbor_cors_origin map.
-        add_header Access-Control-Allow-Origin $harbor_cors_origin always;
-        add_header Cache-Control "no-store" always;
-        add_header X-Frame-Options "DENY" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header Referrer-Policy "no-referrer-when-downgrade" always;
-        return 404 "404 Not Found\n";
-    }
+    # Included, not inlined: a named location is scoped to its server, and
+    # harbor-updates.conf refers to @notfound from both blocks.
+    include /etc/nginx/snippets/harbor-notfound.conf;
 }

--- a/apps/harbor-site/harbor-updates.conf
+++ b/apps/harbor-site/harbor-updates.conf
@@ -1,0 +1,49 @@
+# The desktop updater surface, included by BOTH server blocks.
+#
+# THE REASON THIS IS A SNIPPET RATHER THAN TWO COPIES: every installed Harbor
+# binary has https://harbor.site/updates/latest.json compiled into it via
+# tauri.conf.json and cannot be repointed afterwards. So harbor.site must keep
+# answering this path for the life of those binaries, and it must answer
+# IDENTICALLY to harbor.${dns_domain}. Two copies of these blocks would drift,
+# and the drift would only show up as clients silently not updating.
+#
+# harbor.site DELIBERATELY DOES NOT REDIRECT THIS PATH. Every other machine
+# surface there is a 308, which is safe because a 308 preserves the method and
+# reqwest follows redirects by default. This one is not worth that bet: if the
+# updater does not follow the redirect, every installed client stops updating
+# and there is no channel left to reach them through. Serving it directly on
+# both hostnames removes the question rather than answering it.
+#
+# Requires: the $harbor_chan and $harbor_updates_path maps, and @notfound
+# (harbor-notfound.conf). Both server blocks that include this must include
+# harbor-notfound.conf too.
+
+# The channel manifest. EXACT match, so it beats the prefix location below.
+#
+# Cache-Control is no-store and Vary carries the channel header. Without the
+# Vary an edge cache can hand a beta manifest to a stable client, which silently
+# up- or downgrades every installed desktop app pointed at it -- invisible until
+# someone reports the wrong version.
+location = /updates/latest.json {
+    set $harbor_key "updates/latest${harbor_chan}.json";
+    include /etc/nginx/snippets/harbor-origin.conf;
+    error_page 403 404 = @notfound;
+    add_header Cache-Control "no-store" always;
+    add_header Vary "X-Harbor-Channel" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+}
+
+# The artifacts: installers, .app.tar.gz, .dmg and their .sig files. Version is
+# in the filename, so they are immutable and cache hard -- ~250 MB each, which
+# is the whole reason for keeping them behind Cloudflare.
+location ^~ /updates/ {
+    set $harbor_key "updates/$harbor_updates_path";
+    include /etc/nginx/snippets/harbor-origin.conf;
+    error_page 403 404 = @notfound;
+    add_header Cache-Control "public, max-age=2592000, immutable" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+}


### PR DESCRIPTION
`harbor.site` **308'd** `/updates/` to `harbor.elfhosted.com`. That very probably worked — Tauri v2's updater uses reqwest, which follows redirects by default — but **"very probably" is the wrong standard here**, because this is the only unrecoverable failure in the migration.

Every installed binary has `https://harbor.site/updates/latest.json` compiled into `tauri.conf.json` and **cannot be repointed after the fact**. If the updater had not followed the redirect, every installed client would have silently stopped updating with no channel left to reach them. Serving the path directly removes the question rather than answering it — and removes the "test with a signed client before the flip" step that only the maintainer could perform.

This also matches what the maintainer asked for before pointing the A records: *"as long as /updates/ is being served directly it shouldnt strand users"*. It was **not** being served directly.

## Shared snippets, not two copies

The two `/updates/` locations and `@notfound` move into snippets included by **both** server blocks, so the hostnames are identical **by construction** rather than by two copies that happen to agree today.

`@notfound` has to move as well — a named location is scoped to its server, and the updates snippet refers to it from both.

## Two stale comments corrected

The file claimed `/updates/` was *"NOT ported, on purpose"* when the default host has served it for days, and carried a pre-flight note about testing the redirect that no longer applies.

## goss

Both hosts, same path. **500 is the expected status, not a failure** — there are no Backblaze credentials in CI, so the origin fetch throws. What is asserted is that the request *reached the origin* instead of being answered with a redirect; 301/302/307/308 all fail it.

The two entries use different spellings of loopback deliberately: goss keys http resources by URL, so the same URL twice would be a **duplicate YAML key**, the second silently replacing the first and the `harbor.site` case never running.

## Verified in the built image

| Check | Result |
|---|---|
| `/updates/latest.json` + an artifact path × `harbor.site`, `www.harbor.site`, `harbor.elfhosted.com`, default | **500 on all eight, no redirect** |
| `harbor.site` still redirects everything else | `/` 301, `/v1/feedback` 308, `/api/igdb/games` 308, `/themes/api/` 308, `/relay` 404 |
| Default host unregressed | `PUT /` 405, `/healthz` 200, `/robots.txt` 200 |