### PR TITLE
chore(autopulse): rebuild nudge to pick up webhook retry-loop patch

### DIFF
--- a/apps/autopulse/ci/latest.sh
+++ b/apps/autopulse/ci/latest.sh
@@ -7,3 +7,6 @@ else
   version=$(curl -sX GET "https://api.github.com/repos/d3v1l1989/targeted-scans/commits/main" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.sha[0:7]')
 fi
 printf "%s" "${version}"
+
+# rebuild nudge 2026-08-02: pick up containers-private autopulse patch 0002
+# (webhook 500->200 retry-loop fix, containers-private#118). No behaviour change here.


### PR DESCRIPTION
Comment-only touch to `apps/autopulse/ci/latest.sh` to fire the **Image: Rebuild** workflow for autopulse on merge (it triggers on `apps/**` pushes; a containers-private-only change doesn't).

The build overlays `apps/` from **containers-private**, so the rebuilt autopulse image includes the just-merged **[containers-private#118](https://github.com/elfhosted/containers-private/pull/118)** — the webhook 500→200 retry-loop fix. autopulse's image tag is the upstream `targeted-scans` SHA (unchanged), which is why the rebuild needs this nudge.

**Pickup caveat:** because the tag is unchanged, the rebuilt image lands on the **same tag with a new digest** — running autopulse pods won't auto-roll. After the build completes, they need a restart (imagePullPolicy) or a digest re-pin to actually pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)