### PR TITLE
fix(harbor-site): answer CORS preflight instead of redirecting it

### DIFF
--- a/apps/harbor-site/Dockerfile
+++ b/apps/harbor-site/Dockerfile
@@ -33,6 +33,7 @@ COPY apps/harbor-site/harbor-site.conf             /etc/nginx/conf.d/harbor-site
 COPY apps/harbor-site/harbor-origin.conf           /etc/nginx/snippets/harbor-origin.conf
 COPY apps/harbor-site/harbor-updates.conf          /etc/nginx/snippets/harbor-updates.conf
 COPY apps/harbor-site/harbor-notfound.conf         /etc/nginx/snippets/harbor-notfound.conf
+COPY apps/harbor-site/harbor-cors-preflight.conf   /etc/nginx/snippets/harbor-cors-preflight.conf
 COPY apps/harbor-site/harbor-site.js               /etc/nginx/njs/harbor-site.js
 COPY apps/harbor-site/05-harbor-site-resolver.sh   /docker-entrypoint.d/05-harbor-site-resolver.sh
 
@@ -49,6 +50,7 @@ RUN chmod 0755 /docker-entrypoint.d/05-harbor-site-resolver.sh \
                /etc/nginx/snippets/harbor-origin.conf \
                /etc/nginx/snippets/harbor-updates.conf \
                /etc/nginx/snippets/harbor-notfound.conf \
+               /etc/nginx/snippets/harbor-cors-preflight.conf \
                /etc/nginx/njs/harbor-site.js \
                /usr/share/nginx/seo/robots.txt \
                /usr/share/nginx/seo/sitemap.xml

--- a/apps/harbor-site/ci/latest.sh
+++ b/apps/harbor-site/ci/latest.sh
@@ -47,6 +47,10 @@
 #          a redirect the updater failed to follow would strand every client with
 #          no way to reach them. Both hostnames now include one shared snippet,
 #          so they cannot drift.
+#   1.3.0  answer CORS preflight at the harbor.site edge instead of redirecting
+#          it. Browsers do not follow a 3xx on an OPTIONS preflight, so the 308
+#          broke every preflighted request -- writes -- while leaving simple
+#          GETs working. Found in production after the cutover.
 set -uo pipefail
 
-printf '%s' "1.2.0"
+printf '%s' "1.3.0"

--- a/apps/harbor-site/harbor-cors-preflight.conf
+++ b/apps/harbor-site/harbor-cors-preflight.conf
@@ -1,0 +1,40 @@
+# CORS preflight, answered HERE rather than redirected.
+#
+# THE BUG THIS FIXES: a browser will not follow a redirect on a preflight. The
+# Fetch spec requires the response to an OPTIONS preflight to be a 2xx carrying
+# the Access-Control-* headers; a 3xx is a failed preflight, full stop, and the
+# real request is never sent. So harbor.site's 308 -- correct for every other
+# method, because it preserves POST bodies where a 301 would not -- is precisely
+# wrong for OPTIONS.
+#
+# The symptom is asymmetric and that is what makes it confusing: simple GETs
+# work, because they are not preflighted and the browser happily follows the
+# 308. Anything that triggers a preflight -- a POST with Content-Type:
+# application/json, or any request carrying Authorization -- dies at the
+# preflight with "Failed to fetch". Reads look fine while writes silently drop.
+#
+# ONLY OPTIONS IS CARVED OUT. GET/POST/PATCH/PUT/DELETE keep redirecting, so the
+# method-preserving 308 behaviour is untouched.
+#
+# The values mirror what harbor.${dns_domain} already answers, verified against
+# it rather than invented:
+#
+#   access-control-allow-origin: *
+#   access-control-allow-methods: GET, POST, PATCH, PUT, DELETE, OPTIONS
+#   access-control-allow-headers: Content-Type, Authorization
+#
+# A preflight that succeeds here and then hits different values at the
+# destination is worse than no preflight at all, so THESE MUST BE KEPT IN STEP
+# WITH THE APPLICATION. `*` with no Access-Control-Allow-Credentials is
+# deliberate and matches upstream: auth is a bearer token in the Authorization
+# header, not a cookie, so credentialed-CORS rules do not apply and SameSite is
+# not in play.
+if ($request_method = OPTIONS) {
+    add_header Access-Control-Allow-Origin  "*" always;
+    add_header Access-Control-Allow-Methods "GET, POST, PATCH, PUT, DELETE, OPTIONS" always;
+    add_header Access-Control-Allow-Headers "Content-Type, Authorization" always;
+    add_header Access-Control-Max-Age       "86400" always;
+    add_header Content-Length               "0" always;
+    add_header Content-Type                 "text/plain" always;
+    return 204;
+}

--- a/apps/harbor-site/harbor-site.conf
+++ b/apps/harbor-site/harbor-site.conf
@@ -169,9 +169,23 @@ server {
     include /etc/nginx/snippets/harbor-notfound.conf;
     include /etc/nginx/snippets/harbor-updates.conf;
 
-    location ^~ /api/        { return 308 https://harbor.elfhosted.com$request_uri; }
-    location ^~ /themes/api/ { return 308 https://harbor.elfhosted.com$request_uri; }
-    location ^~ /v1/         { return 308 https://harbor.elfhosted.com$request_uri; }
+    # Each answers an OPTIONS preflight itself and 308s everything else. A
+    # browser will not follow a redirect on a preflight -- see
+    # harbor-cors-preflight.conf -- so redirecting OPTIONS breaks every
+    # preflighted request while leaving simple GETs working, which is exactly
+    # how it presented after the cutover: reads fine, writes silently dropped.
+    location ^~ /api/ {
+        include /etc/nginx/snippets/harbor-cors-preflight.conf;
+        return 308 https://harbor.elfhosted.com$request_uri;
+    }
+    location ^~ /themes/api/ {
+        include /etc/nginx/snippets/harbor-cors-preflight.conf;
+        return 308 https://harbor.elfhosted.com$request_uri;
+    }
+    location ^~ /v1/ {
+        include /etc/nginx/snippets/harbor-cors-preflight.conf;
+        return 308 https://harbor.elfhosted.com$request_uri;
+    }
 
     # WebSocket upgrade: a redirect breaks the handshake rather than moving it.
     location ^~ /relay { return 404; }


### PR DESCRIPTION
**Reported from production after the cutover:** community themes fail to load and sharing a collection silently does nothing, while ordinary browsing is fine.

## Why

**A browser will not follow a redirect on a preflight.** The Fetch spec requires an `OPTIONS` preflight to be answered with a **2xx** carrying the `Access-Control-*` headers; a 3xx is a failed preflight and the real request is never sent.

So the `308` — correct for every other method, because it preserves POST bodies where a 301 would not — is exactly wrong for `OPTIONS`.

That explains the asymmetry: simple GETs aren't preflighted, so they follow the 308 and work. Anything preflighted (a POST with `Content-Type: application/json`, or any request carrying `Authorization`) dies before it is sent. **Reads look healthy while writes disappear** — far more confusing than everything breaking.

## The fix

`/api/`, `/themes/api/` and `/v1/` now answer `OPTIONS` themselves and 308 everything else. `/updates/` needs nothing — it is served here, not redirected.

Values mirror what `harbor.${dns_domain}` already returns, **read off it rather than invented**:

```
access-control-allow-origin:  *
access-control-allow-methods: GET, POST, PATCH, PUT, DELETE, OPTIONS
access-control-allow-headers: Content-Type, Authorization
```

A preflight that succeeds at the edge then meets *different* values at the destination is worse than no preflight, so these must stay in step with the application.

## On the credentialed question raised alongside this

`*` with **no** `Access-Control-Allow-Credentials` is correct here, not an oversight. The destination sends no `Allow-Credentials` and no `Set-Cookie`, and lists `Authorization` in `Allow-Headers` — **auth is a bearer token, not a cookie**. Credentialed-CORS rules don't apply and `SameSite` is not in play on this path.

## Verified in the built image

| Request | Result |
|---|---|
| `OPTIONS` × `/themes/api/x`, `/api/igdb/games`, `/v1/feedback` | **204**, all three headers present and matching the destination |
| `POST/GET/PATCH/PUT/DELETE /themes/api/x` | **308**, unchanged |
| `GET /` → 301 · `GET /relay` → 404 · `/updates/` → origin, not a redirect | unchanged |
| default host: `PUT /` → 405, `/robots.txt` → 200 | unchanged |