### PR TITLE
fix(harbor-site): serve the data surfaces on harbor.site instead of redirecting

### DIFF
--- a/apps/harbor-site/Dockerfile
+++ b/apps/harbor-site/Dockerfile
@@ -34,6 +34,7 @@ COPY apps/harbor-site/harbor-origin.conf           /etc/nginx/snippets/harbor-or
 COPY apps/harbor-site/harbor-updates.conf          /etc/nginx/snippets/harbor-updates.conf
 COPY apps/harbor-site/harbor-notfound.conf         /etc/nginx/snippets/harbor-notfound.conf
 COPY apps/harbor-site/harbor-cors-preflight.conf   /etc/nginx/snippets/harbor-cors-preflight.conf
+COPY apps/harbor-site/harbor-data.conf             /etc/nginx/snippets/harbor-data.conf
 COPY apps/harbor-site/harbor-site.js               /etc/nginx/njs/harbor-site.js
 COPY apps/harbor-site/05-harbor-site-resolver.sh   /docker-entrypoint.d/05-harbor-site-resolver.sh
 
@@ -51,6 +52,7 @@ RUN chmod 0755 /docker-entrypoint.d/05-harbor-site-resolver.sh \
                /etc/nginx/snippets/harbor-updates.conf \
                /etc/nginx/snippets/harbor-notfound.conf \
                /etc/nginx/snippets/harbor-cors-preflight.conf \
+               /etc/nginx/snippets/harbor-data.conf \
                /etc/nginx/njs/harbor-site.js \
                /usr/share/nginx/seo/robots.txt \
                /usr/share/nginx/seo/sitemap.xml

--- a/apps/harbor-site/ci/latest.sh
+++ b/apps/harbor-site/ci/latest.sh
@@ -51,6 +51,11 @@
 #          it. Browsers do not follow a 3xx on an OPTIONS preflight, so the 308
 #          broke every preflighted request -- writes -- while leaving simple
 #          GETs working. Found in production after the cutover.
+#   1.4.0  serve /api/curated/, /api/hero/, /feed/ and /badges/ on harbor.site
+#          instead of redirecting them. Completes the same fix: a cross-origin
+#          redirect strips Authorization and fails a preflight, so anything the
+#          app fetches must be answered on the host it was called on. The
+#          authenticated paths were fixed at Traefik; these four reach nginx.
 set -uo pipefail
 
-printf '%s' "1.3.0"
+printf '%s' "1.4.0"

--- a/apps/harbor-site/harbor-data.conf
+++ b/apps/harbor-site/harbor-data.conf
@@ -1,0 +1,74 @@
+# The read-only data surfaces, included by BOTH server blocks.
+#
+# WHY THESE ARE SHARED RATHER THAN REDIRECTED FROM harbor.site: the SPA fetches
+# them cross-origin, and a redirect is not free for a fetch(). Browsers strip
+# the Authorization header on a cross-origin redirect, and a redirected
+# preflight fails outright -- so anything the app calls has to be ANSWERED on
+# the host it was called on, not pointed elsewhere. These four are the paths
+# that reach nginx; the rest (/themes/api, /v1/, the per-service /api/*) are
+# routed by Traefik straight to their backends and never arrive here.
+#
+# All four are unauthenticated GETs, so a redirect merely cost them a round
+# trip rather than breaking them. Serving them directly removes the round trip
+# and, more importantly, removes a class of bug from the whole surface instead
+# of only the parts that had already broken.
+#
+# Requires: the $harbor_curated_path, $harbor_hero_path, $harbor_apex_path and
+# $harbor_badge_cache maps, harbor-origin.conf, and @notfound
+# (harbor-notfound.conf). Both including blocks already have all of them.
+#
+# Location precedence makes this safe next to harbor.site's catch-all
+# `location ^~ /api/`: nginx picks the LONGEST matching prefix, so
+# /api/curated/ and /api/hero/ win here regardless of file order.
+
+# --- /api/curated/ : was `alias /opt/harbor-curated/` ---
+location ^~ /api/curated/ {
+    set $harbor_key "curated/$harbor_curated_path";
+    include /etc/nginx/snippets/harbor-origin.conf;
+    error_page 403 404 = @notfound;
+    add_header Access-Control-Allow-Origin "*" always;
+    add_header Cache-Control "public, max-age=21600" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+}
+
+# --- /api/hero/ : was `alias /opt/harbor-hero/` ---
+location ^~ /api/hero/ {
+    set $harbor_key "hero/$harbor_hero_path";
+    include /etc/nginx/snippets/harbor-origin.conf;
+    error_page 403 404 = @notfound;
+    add_header Access-Control-Allow-Origin "*" always;
+    add_header Cache-Control "public, max-age=1800" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+}
+
+# --- /feed/ : inside the docroot; the VPS block existed only to add CORS ---
+location ^~ /feed/ {
+    set $harbor_key "apex$harbor_apex_path";
+    include /etc/nginx/snippets/harbor-origin.conf;
+    error_page 403 404 = @notfound;
+    add_header Access-Control-Allow-Origin "*" always;
+    add_header Cache-Control "public, max-age=1800" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+}
+
+# --- /badges/ : CORS-open, JSON never cached, images cached a week ---
+# No SPA fallback: the VPS block ended with `try_files $uri =404`, and a badge
+# consumer parsing JSON must get a 404 rather than a 200 full of HTML.
+location ^~ /badges/ {
+    set $harbor_key "apex$harbor_apex_path";
+    include /etc/nginx/snippets/harbor-origin.conf;
+    error_page 403 404 = @notfound;
+    add_header Access-Control-Allow-Origin "*" always;
+    add_header Access-Control-Allow-Methods "GET, HEAD, OPTIONS" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Cache-Control $harbor_badge_cache always;
+}
+

--- a/apps/harbor-site/harbor-site.conf
+++ b/apps/harbor-site/harbor-site.conf
@@ -169,6 +169,18 @@ server {
     include /etc/nginx/snippets/harbor-notfound.conf;
     include /etc/nginx/snippets/harbor-updates.conf;
 
+    # The read-only data surfaces the SPA fetches: /api/curated/, /api/hero/,
+    # /feed/ and /badges/. SERVED here, not redirected, for the same reason as
+    # /updates/ -- a cross-origin redirect is not free for a fetch(), and the
+    # rule that keeps biting is "answer where you were called, do not point
+    # elsewhere". Same file as harbor.${dns_domain} includes, so the two cannot
+    # drift.
+    #
+    # These beat the catch-all `location ^~ /api/` below on longest-prefix
+    # match, so /api/curated/ and /api/hero/ are served while everything else
+    # under /api/ still redirects.
+    include /etc/nginx/snippets/harbor-data.conf;
+
     # Each answers an OPTIONS preflight itself and 308s everything else. A
     # browser will not follow a redirect on a preflight -- see
     # harbor-cors-preflight.conf -- so redirecting OPTIONS breaks every
@@ -316,56 +328,10 @@ server {
         return 404 "404 Not Found\n";
     }
 
-    # --- /api/curated/ : was `alias /opt/harbor-curated/` ---
-    location ^~ /api/curated/ {
-        set $harbor_key "curated/$harbor_curated_path";
-        include /etc/nginx/snippets/harbor-origin.conf;
-        error_page 403 404 = @notfound;
-        add_header Access-Control-Allow-Origin "*" always;
-        add_header Cache-Control "public, max-age=21600" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Frame-Options "DENY" always;
-        add_header Referrer-Policy "no-referrer-when-downgrade" always;
-    }
-
-    # --- /api/hero/ : was `alias /opt/harbor-hero/` ---
-    location ^~ /api/hero/ {
-        set $harbor_key "hero/$harbor_hero_path";
-        include /etc/nginx/snippets/harbor-origin.conf;
-        error_page 403 404 = @notfound;
-        add_header Access-Control-Allow-Origin "*" always;
-        add_header Cache-Control "public, max-age=1800" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Frame-Options "DENY" always;
-        add_header Referrer-Policy "no-referrer-when-downgrade" always;
-    }
-
-    # --- /feed/ : inside the docroot; the VPS block existed only to add CORS ---
-    location ^~ /feed/ {
-        set $harbor_key "apex$harbor_apex_path";
-        include /etc/nginx/snippets/harbor-origin.conf;
-        error_page 403 404 = @notfound;
-        add_header Access-Control-Allow-Origin "*" always;
-        add_header Cache-Control "public, max-age=1800" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Frame-Options "DENY" always;
-        add_header Referrer-Policy "no-referrer-when-downgrade" always;
-    }
-
-    # --- /badges/ : CORS-open, JSON never cached, images cached a week ---
-    # No SPA fallback: the VPS block ended with `try_files $uri =404`, and a badge
-    # consumer parsing JSON must get a 404 rather than a 200 full of HTML.
-    location ^~ /badges/ {
-        set $harbor_key "apex$harbor_apex_path";
-        include /etc/nginx/snippets/harbor-origin.conf;
-        error_page 403 404 = @notfound;
-        add_header Access-Control-Allow-Origin "*" always;
-        add_header Access-Control-Allow-Methods "GET, HEAD, OPTIONS" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Frame-Options "DENY" always;
-        add_header Referrer-Policy "no-referrer-when-downgrade" always;
-        add_header Cache-Control $harbor_badge_cache always;
-    }
+    # Included, not inlined: harbor.site includes the very same file, so the
+    # two hostnames cannot drift. See harbor-data.conf for why it must serve
+    # these rather than redirect them.
+    include /etc/nginx/snippets/harbor-data.conf;
 
     # --- static assets: cached a week, and 404 when missing ---
     # The VPS reached these through a regex location with no try_files, so a


### PR DESCRIPTION
Completes the fix started at the routing layer in elfhosted/infra#17996.

The authenticated paths — `/themes/api`, `/v1/`, the per-service `/api/*` — are routed by Traefik straight to their backends and **never reach nginx**, so aliasing those routes onto `harbor.site` was enough. These four *do* reach nginx, and were still being redirected:

```
/api/curated/   308        /feed/     301
/api/hero/      308        /badges/   301
```

They're unauthenticated GETs, so a redirect **cost them a round trip rather than breaking them**. Serving them directly removes the round trip and, more usefully, removes a whole class of bug from the surface instead of only the parts that had already broken.

The rule this migration keeps rediscovering: **anything the app fetches must be answered on the host it was called on.** A cross-origin redirect strips `Authorization` and fails a preflight outright — that bit `/updates/`, then the preflight, then every authenticated call.

## Shape

The four locations move into `harbor-data.conf`, included by **both** server blocks so the hostnames cannot drift — same pattern as `harbor-updates.conf` and `harbor-notfound.conf`.

**Safe next to `harbor.site`'s catch-all `location ^~ /api/`**, which still 308s: nginx selects the **longest matching prefix**, so `/api/curated/` and `/api/hero/` win while everything else under `/api/` keeps redirecting. Independent of file order.

## Verified in the built image, `harbor.site` host throughout

| Path | Result |
|---|---|
| `/api/curated/`, `/api/hero/`, `/feed/`, `/badges/` | reach the origin, **no `Location` header** |
| `/api/igdb`, `/api/imdb`, `/themes/api`, `/v1/` | still **308** |
| `GET /` → 301 · `OPTIONS` preflight → 204 · `/relay` → 404 | unchanged |
| default host: `/feed/` unchanged, `PUT /` → 405 | unchanged |
