### PR TITLE
chore(catbox): rebuild nudge to pick up v0.87.2 (reap circuit-break)

### DIFF
--- a/apps/catbox/ci/latest.sh
+++ b/apps/catbox/ci/latest.sh
@@ -5,3 +5,5 @@
 # pre-first-release window, which CI then handles gracefully.
 version=$(curl -sX GET https://api.github.com/repos/elfhosted/catbox/releases/latest --header "Authorization: Bearer ${ZURG_GH_CREDS}" | jq --raw-output '.tag_name // empty')
 printf "%s" "${version}"
+# Rebuild nudge: pick up catbox v0.87.2 (torbox dematerialize reap
+# circuit-break + backoff) — the fleet-wide CPU churn fix.


### PR DESCRIPTION
One-line nudge to force an `Image: Rebuild` of catbox now that **v0.87.2** is released (the torbox dematerialize reap circuit-break + backoff — fixes the fleet-wide CPU churn seen on 7/11 party instances during torbox `DATABASE_ERROR` spells). `latest.sh` resolves `releases/latest`, so the rebuild picks up 0.87.2 → `ghcr.io/elfhosted/catbox:0.87.2 + rolling`.

The scheduled "Release: Schedule" run predated the 04:12Z release (and failed on an unrelated app), so triggering manually. Tenant rollout still needs the digest pin bumped (renovate is currently auth-broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)