### PR TITLE
feat(harbor-relay): add the build definition that never existed

### DIFF
--- a/apps/harbor-relay/Dockerfile
+++ b/apps/harbor-relay/Dockerfile
@@ -1,0 +1,73 @@
+# syntax=docker/dockerfile:1
+#
+# harbor-relay: the public Watch Together relay (wss://pub.harbor.site).
+#
+# PORTED FROM harbor-hosted deploy/relay/Dockerfile, with one substantive change:
+# that file states its build context is "a checkout of harborstremio/
+# pub.harbor.site", which stopped being true when the relay was vendored. The
+# source now lives at services/harbor-relay/src/ in harbor-hosted, so this clones
+# harbor-hosted at the release tag like every other vendored service here.
+#
+# WHY THIS FILE EXISTS AT ALL. Nothing built harbor-relay. harbor-hosted retired
+# build-images.yml when image builds moved to elfhosted/containers, but the relay
+# was never added on this side -- so it has no build path in either repo. The
+# running harbor-relay-v0.3.0 predates the retirement, and cutting v0.4.0 would
+# have produced a git tag with no image behind it and nothing reporting a
+# problem.
+#
+# uWebSockets.js resolves from a GitHub tag and compiles a native binding, so the
+# build stage needs git and a toolchain. The runtime stage does not.
+
+FROM alpine:latest AS cloner
+ARG VERSION
+ARG ZURG_GH_CREDS
+RUN apk add --no-cache git
+RUN echo "harbor-hosted @ ${VERSION}" \
+ && git clone "https://${ZURG_GH_CREDS}@github.com/harborstremio/harbor-hosted.git" /source \
+ && git -C /source checkout --detach "${VERSION}"
+
+FROM node:20-bookworm-slim AS build
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git ca-certificates python3 build-essential \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+# package-lock.json comes across too: npm ci refuses to run without it, and the
+# native binding is pinned there rather than in package.json.
+COPY --from=cloner /source/services/harbor-relay/src/package.json /source/services/harbor-relay/src/package-lock.json ./
+RUN npm ci --omit=dev
+COPY --from=cloner /source/services/harbor-relay/src/src ./src
+
+FROM node:20-bookworm-slim AS runtime
+ENV NODE_ENV=production
+# TCP rather than the unix socket the VPS used. Both are supported and they are
+# mutually exclusive, so RELAY_UNIX_SOCKET stays unset.
+ENV RELAY_HOST=0.0.0.0
+ENV RELAY_PORT=8080
+# Client IPs arrive via the forwarded header, so per-IP limits apply to the real
+# client rather than to the ingress.
+ENV RELAY_TRUST_PROXY=1
+
+WORKDIR /app
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/src ./src
+COPY --from=cloner /source/services/harbor-relay/src/package.json ./
+
+# The systemd unit set LimitNOFILE=200000. Each WebSocket is one fd and the relay
+# ceiling is RELAY_CONN_MAX (default 40000), so a runtime default of 1024 refuses
+# connections in the low thousands and presents as a network fault rather than a
+# limit. There is no pod-level field for this in Kubernetes -- it is set on the
+# node or the runtime class, which is why this is a comment and not a directive.
+
+USER node
+EXPOSE 8080
+
+# No disk writes, no children, no persistence -- nothing to preserve on stop.
+STOPSIGNAL SIGTERM
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD ["node","-e","fetch('http://127.0.0.1:8080/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+
+LABEL org.opencontainers.image.title="harbor-relay" \
+      org.opencontainers.image.description="Harbor Watch Together relay (uWebSockets.js)"
+
+CMD ["node", "src/server.js"]

--- a/apps/harbor-relay/ci/goss.yaml
+++ b/apps/harbor-relay/ci/goss.yaml
@@ -1,0 +1,24 @@
+---
+# harbor-relay smoke test.
+#
+# /health is answered from memory and needs no upstream, so it is meaningful with
+# no credentials and no network -- unlike most services here.
+process:
+  node:
+    running: true
+
+http:
+  http://localhost:8080/health:
+    status: 200
+    timeout: 5000
+    body:
+      - '"service":"harbor-together-relay"'
+
+# The relay must bind the WILDCARD, not loopback. Eight of the nine vendored
+# harbor services shipped bound to 127.0.0.1 and were unroutable from their own
+# Service while every probe passed, because goss runs inside the container's
+# network namespace and cannot tell the difference. 1F90 is hex 8080; 00000000
+# is the v4 wildcard and 32 zeroes the v6 form. st 0A is LISTEN.
+command:
+  "grep -qE '^ *[0-9]+: (00000000|0{32}):1F90 [0-9A-F]{8,32}:0000 0A ' /proc/net/tcp /proc/net/tcp6":
+    exit-status: 0

--- a/apps/harbor-relay/ci/latest.sh
+++ b/apps/harbor-relay/ci/latest.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# harbor-imdb: one of the nine Harbor backend services.
+# harbor-relay: one of the nine Harbor backend services.
 #
 # Source: https://github.com/harborstremio/harbor-hosted (PRIVATE), at
-# services/harbor-imdb/src. These images integrate with ElfHosted-internal
+# services/harbor-relay/src. These images integrate with ElfHosted-internal
 # services (EMDB, ElfCache), so they are ElfHosted artifacts and are not
 # self-hostable.
 #
@@ -21,10 +21,10 @@
 #
 # PREFERRED: the newest per-component release-please tag. harbor-hosted's
 # release-please-config.json sets include-component-in-tag, include-v-in-tag and
-# tag-separator "-", so tags read harbor-imdb-v0.1.0. That form is a valid git ref
+# tag-separator "-", so tags read harbor-relay-v0.1.0. That form is a valid git ref
 # and a valid Docker tag, so it is emitted verbatim.
 #
-# FALLBACK: no harbor-imdb-v* tag exists yet, because the vendoring PR (#1) is
+# FALLBACK: no harbor-relay-v* tag exists yet, because the vendoring PR (#1) is
 # unmerged and release-please has never run against this repo. So the fallback
 # is the SHORT SHA of the vendoring branch head. Two more obvious fallbacks were
 # rejected:
@@ -43,18 +43,12 @@
 # merges and before the first release-please run.
 set -uo pipefail
 
-# harbor-relay was built from harborstremio/pub.harbor.site until 2026-07-31 and
-# emitted v9-stale-<sha7>, because that repo's HEAD is v9, carries no tags, and the
-# VPS runs v10. The source is now vendored into harbor-hosted at v10, so this reads
-# component tags like every other vendored service and the stale marker is gone.
-# If this ever returns a bare sha again, the tag lookup failed -- do not ship it.
-
 repo="harborstremio/harbor-hosted"
 component="harbor-relay"
 branch="feat/vendored-services-and-deployment"
 auth_header="Authorization: Bearer ${ZURG_GH_CREDS}"
 
-# Newest harbor-imdb-v* tag. Sorted by version rather than trusting the API's
+# Newest harbor-relay-v* tag. Sorted by version rather than trusting the API's
 # ordering, and filtered to x.y.z so a stray tag cannot win.
 version="$(
   curl -fsSL -H "${auth_header}" \


### PR DESCRIPTION
**`harbor-relay` has no build path in either repo.** harbor-hosted retired `build-images.yml` when image builds moved here, but the relay was never added on this side — so nothing builds it. The running `harbor-relay-v0.3.0` predates the retirement.

It surfaced from the opposite direction: release-please has an open PR proposing **harbor-relay 0.4.0**, and merging it would have cut a git tag **with no image behind it**. Nothing would have failed — the tag would exist, the HelmRelease would keep pointing at v0.3.0, and the release would look done.

## Ported, with one substantive change

From harbor-hosted `deploy/relay/Dockerfile`. That file declares its build context to be *"a checkout of `harborstremio/pub.harbor.site`"* — which stopped being true when the relay was vendored. Source now comes from `services/harbor-relay/src/` in harbor-hosted, cloned at the release tag like every other vendored service here.

**Kept from the original, because each had a reason:**

- git + toolchain in the build stage — `uWebSockets.js` resolves from a GitHub tag and compiles a native binding
- `RELAY_TRUST_PROXY=1` — client IPs arrive via the forwarded header, so per-IP limits apply to the client rather than the ingress
- the `LimitNOFILE` note — each WebSocket is one fd against a 40000 ceiling; a 1024 default refuses connections in the low thousands and presents as a network fault
- `package-lock.json` is copied too — `npm ci` refuses without it, and the native binding is pinned there

## goss asserts the wildcard bind, not just health

**Eight of the nine vendored harbor services shipped bound to `127.0.0.1`** — passing every probe while being unroutable from their own Service, because goss runs inside the container's network namespace and cannot tell the difference. Reading `/proc/net/tcp` can.

## Verified against a local build at v0.3.0

| Check | Result |
|---|---|
| `/health` | **200**, `{"service":"harbor-together-relay","version":10}` |
| goss body pattern | matches |
| wildcard bind | `00000000:1F90` in `/proc/net/tcp` — not `0100007F` |
| `goss.yaml` | passes `goss render` on the pinned **v0.3.18** |

Local build is arm64; CI builds `linux/amd64` per `metadata.json`, and the native binding compiles per architecture — so CI is the real test of the toolchain stage.
