### PR TITLE
fix(ci): stop reporting supply-chain scanner failures as malware findings

### DIFF
--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -361,9 +361,35 @@ jobs:
             # document, so there is no "find the JSON in mixed output" step for
             # report content to interfere with.
             sock_json="$(mktemp)"; sock_err="$(mktemp)"
+
+            # PINNED, AND WITH form-data SUPPLIED EXPLICITLY.
+            #
+            # `npx -y socket` fetched whatever was tagged latest at build time --
+            # unpinned third-party code executing in a job that pushes production
+            # images, which is the very thing this step exists to guard against.
+            # It also meant one bad upstream release broke every Node build here
+            # at once, which is exactly what happened.
+            #
+            # socket@1.1.152 declares only @socketsecurity/socket-patch, yet its
+            # bundle require()s form-data when it uploads a manifest, so the scan
+            # dies with "Cannot find module 'form-data'" the moment it has
+            # something to send. Apps whose scan finds zero files never upload and
+            # never see it. Installing form-data as a SIBLING of socket lets node
+            # resolve it by walking up from socket/dist/, which is verified to
+            # work. Upstream bug; drop the extra package once it is fixed.
+            #
+            # 2.x is published but deprecated upstream as "bad build", so 1.1.152
+            # is the only usable release and the pin has to be bumped by hand.
+            # That is the intended trade: a deliberate bump beats a silent break.
+            socket_home="$(mktemp -d)"
+            if ! npm i --silent --no-audit --no-fund --prefix "$socket_home" socket@1.1.152 form-data >"$sock_err" 2>&1; then
+              cat "$sock_err"
+              socket_class="unclassified"
+              echo "Could not install the Socket CLI; not treating that as a scan result."
+            else
             for attempt in 1 2 3; do
               socket_rc=0
-              ( cd "$dir" && npx -y socket scan create --report --json --org funky-penguin . ) >"$sock_json" 2>"$sock_err" || socket_rc=$?
+              ( cd "$dir" && "$socket_home/node_modules/.bin/socket" scan create --report --json --org funky-penguin . ) >"$sock_json" 2>"$sock_err" || socket_rc=$?
               cat "$sock_err"; cat "$sock_json"
               [ "$socket_rc" = "0" ] && { socket_class="pass"; break; }
 
@@ -397,6 +423,7 @@ jobs:
               fi
               [ "$attempt" != "3" ] && { echo "Socket transport failure (attempt $attempt/3), retrying..."; sleep $(( attempt * 10 )); }
             done
+            fi
             echo "::endgroup::"
 
             case "$socket_class" in

--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -378,11 +378,18 @@ jobs:
             # resolve it by walking up from socket/dist/, which is verified to
             # work. Upstream bug; drop the extra package once it is fixed.
             #
-            # 2.x is published but deprecated upstream as "bad build", so 1.1.152
-            # is the only usable release and the pin has to be bumped by hand.
-            # That is the intended trade: a deliberate bump beats a silent break.
+            # BOTH are pinned exactly, form-data included. A bare specifier there
+            # would have left the very hole this commit closes: the Socket bundle
+            # require()s it directly, so any newer release would execute
+            # unreviewed code in the job that pushes production images, and an
+            # incompatible one would break every Node build again.
+            #
+            # 2.x of socket is published but deprecated upstream as "bad build",
+            # so 1.1.152 is the only usable release and both pins have to be
+            # bumped by hand. That is the intended trade: a deliberate bump beats
+            # a silent break.
             socket_home="$(mktemp -d)"
-            if ! npm i --silent --no-audit --no-fund --prefix "$socket_home" socket@1.1.152 form-data >"$sock_err" 2>&1; then
+            if ! npm i --silent --no-audit --no-fund --prefix "$socket_home" socket@1.1.152 form-data@4.0.6 >"$sock_err" 2>&1; then
               cat "$sock_err"
               socket_class="unclassified"
               echo "Could not install the Socket CLI; not treating that as a scan result."

--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -289,7 +289,8 @@ jobs:
         run: |
           set -uo pipefail
           IMAGE="ghcr.io/${{ github.repository_owner }}/${{ steps.vars.outputs.chan_tag_testing }}"
-          rc=0
+          osv_rc=0
+          socket_rc=0
 
           cid="$(docker create "$IMAGE")"
           dir="$(mktemp -d)"
@@ -318,7 +319,7 @@ jobs:
           echo "::endgroup::"
           if grep -q '"id"[[:space:]]*:[[:space:]]*"MAL-' /tmp/osv.json 2>/dev/null; then
             echo "::error::OSV flagged a MALICIOUS package (MAL-*) in ${{ matrix.image.app }}."
-            rc=1
+            osv_rc=1
           fi
 
           # --- Socket.dev: behavioral supply-chain gate ---
@@ -327,18 +328,96 @@ jobs:
           # (plus OSV's precise MAL-* check above). --org is required so the CLI
           # runs non-interactively in CI; the token needs org security-policy read
           # scope (otherwise socket ci 403s).
+          #
+          # A SCANNER THAT COULD NOT RUN IS NOT A FINDING. Previously every
+          # non-zero exit was reported as "flagged malware/policy issues" and
+          # blocked the push, so a Socket API outage or a broken CLI release
+          # failed builds behind a security-shaped error nobody could act on.
+          # That is not hypothetical: the CLI crashed inside its own lazily
+          # fetched bundle ("Cannot find module 'form-data'") and harbor-relay's
+          # builds failed reporting malware that had never been looked for.
+          #
+          # `socket ci` is an alias for `scan create --report`; we call that
+          # directly to add --json, which wraps every outcome in the CLI's own
+          # envelope: {"ok":..,"message":..,"data":{"code":..}}.
+          #
+          # CLASSIFY ON THAT ENVELOPE ONLY, NEVER BY SEARCHING THE REPORT.
+          # The report body contains attacker-controlled text -- package names,
+          # versions, paths, descriptions. Grepping it for error signatures means
+          # a package named `econnreset` could downgrade a genuine malware
+          # verdict to a warning and ship the image. `.message` is CLI-generated
+          # and no dependency can reach it.
+          #
+          # FAIL CLOSED BY DEFAULT: only an outcome positively identified as a
+          # transport failure continues. Anything unrecognised blocks, and says
+          # it could not be classified rather than claiming malware.
           if [ -n "${SOCKET_SECURITY_API_TOKEN:-}" ]; then
             echo "::group::Socket.dev"
-            ( cd "$dir" && npx -y socket ci --org funky-penguin ) || rc=$?
+            socket_class="unclassified"
+            s_code=""
+            # --json puts the envelope alone on STDOUT and every spinner, log and
+            # progress line on STDERR. Keeping them in separate files is what
+            # makes the classification safe: jq only ever sees the CLI's own
+            # document, so there is no "find the JSON in mixed output" step for
+            # report content to interfere with.
+            sock_json="$(mktemp)"; sock_err="$(mktemp)"
+            for attempt in 1 2 3; do
+              socket_rc=0
+              ( cd "$dir" && npx -y socket scan create --report --json --org funky-penguin . ) >"$sock_json" 2>"$sock_err" || socket_rc=$?
+              cat "$sock_err"; cat "$sock_json"
+              [ "$socket_rc" = "0" ] && { socket_class="pass"; break; }
+
+              # jq absent => cannot classify safely => fail closed rather than guess.
+              if ! command -v jq >/dev/null 2>&1; then
+                socket_class="unclassified"; break
+              fi
+              s_ok="$(   jq -r 'if type=="object" then (.ok|tostring) else "x" end'              "$sock_json" 2>/dev/null || echo x  )"
+              s_msg="$(  jq -r 'if type=="object" then (.message // "") else "" end'             "$sock_json" 2>/dev/null || echo "" )"
+              s_code="$( jq -r 'if type=="object" then ((.data.code // "")|tostring) else "" end' "$sock_json" 2>/dev/null || echo "" )"
+
+              if [ "$s_ok" = "false" ] && [ "$s_msg" = "Socket API error" ]; then
+                case "$s_code" in
+                  # ALLOWLIST, not a wildcard. Only statuses that a dependency
+                  # cannot provoke are treated as "the scanner was unavailable".
+                  # A wildcard here is a bypass: a deliberately oversized or
+                  # malformed manifest draws a 413 or 422, and every fail-open
+                  # branch is reachable by an attacker who can make the scan
+                  # fail rather than pass. 400/404/413/422 and a missing status
+                  # are therefore NOT transient -- 404 is also what a wrong org
+                  # slug returns, which would otherwise disable scanning
+                  # permanently and silently.
+                  408|429|500|502|503|504) socket_class="infra" ;;
+                  # A revoked or under-scoped token must NOT fail open either:
+                  # doing so disables scanning for every build.
+                  401|403) socket_class="auth"; break ;;
+                  *)       socket_class="unclassified"; break ;;
+                esac
+              else
+                socket_class="unclassified"; break
+              fi
+              [ "$attempt" != "3" ] && { echo "Socket transport failure (attempt $attempt/3), retrying..."; sleep $(( attempt * 10 )); }
+            done
             echo "::endgroup::"
+
+            case "$socket_class" in
+              pass)  socket_rc=0 ;;
+              infra) echo "::warning::Socket.dev could not complete a scan for ${{ matrix.image.app }} after 3 attempts (transport failure, NOT a finding). Continuing; the OSV MAL-* gate still blocks."
+                     socket_rc=0 ;;
+              auth)  echo "::error::Socket.dev rejected the API token (${s_code}) for ${{ matrix.image.app }}. Scanning is DISABLED until this is fixed; failing closed rather than shipping unscanned."
+                     socket_rc=1 ;;
+              *)     echo "::error::Socket.dev failed for ${{ matrix.image.app }} and the outcome could not be classified. This is either a policy/malware verdict or an unrecognised failure; failing closed. See the Socket.dev group above. If the Socket CLI is broken repo-wide rather than this app being at fault, unset the SOCKET_SECURITY_API_TOKEN secret to skip the behavioral scan deliberately and visibly, rather than widening the transient allowlist."
+                     socket_rc=1 ;;
+            esac
           else
             echo "::warning::SOCKET_SECURITY_API_TOKEN not set — skipping Socket.dev behavioral scan"
           fi
 
-          if [ "$rc" != "0" ]; then
-            echo "::error::Supply-chain scan flagged malware/policy issues for ${{ matrix.image.app }}. Failing before push."
+          # Kept separate on purpose: clearing a Socket transport failure must
+          # never clear a real OSV malware finding, which one shared rc would.
+          if [ "$osv_rc" != "0" ]; then
+            echo "::error::OSV flagged a malicious package in ${{ matrix.image.app }}. Failing before push."
           fi
-          exit "$rc"
+          [ "$osv_rc" = "0" ] && [ "$socket_rc" = "0" ]
 
       - name: Build all platforms
         id: release


### PR DESCRIPTION
## The bug

```bash
( cd "$dir" && npx -y socket ci --org funky-penguin ) || rc=$?
if [ "$rc" != "0" ]; then
  echo "::error::Supply-chain scan flagged malware/policy issues..."
fi
```

**Any** non-zero exit was reported as a malware finding — including a crash, a network blip, or a Socket API outage. A third-party tool failure blocked the image push and announced it as a security finding.

Not hypothetical: the socket CLI crashed inside its own lazily-fetched bundle (`Cannot find module 'form-data'`) while uploading a manifest, and `harbor-relay`'s builds failed twice reporting malware **that had never been looked for**. Apps whose scan finds zero files never upload, so they never hit it — which is why this surfaced on one app rather than all of them.

## The fix

`socket ci` is an alias for `scan create --report`, so we call that directly and add `--json`. That puts the CLI's own envelope — `{ok, message, data.code}` — **alone on stdout**, with every spinner and log line on stderr. The two are captured to separate files.

**Classify on that envelope only, never by searching the report.** The report body carries attacker-controlled text: package names, versions, paths, descriptions. An earlier draft of this fix grepped the whole output for error signatures, which meant a dependency named `econnreset` could have downgraded a genuine malware verdict to a warning and shipped the image. `.message` is CLI-generated and no dependency can reach it.

### Fails closed by default

The continue path is an **allowlist**, not a wildcard: only `408|429|500|502|503|504`, after three attempts.

That distinction is the crux. Every fail-open branch is reachable by an attacker who can make the scan **fail** rather than pass — a deliberately oversized or malformed manifest draws a 413 or 422. So:

| Outcome | Result |
|---|---|
| clean, or 408/429/500/502/503/504 | continue |
| 400 / 404 / 413 / 422 | **block** — attacker-inducible; 404 is also a wrong org slug |
| 401 / 403 | **block** — failing open on a revoked token disables scanning for every build, silently |
| missing status (incl. the CLI crash) | **block** |
| anything unrecognised | **block**, saying it could not be classified — *not* claiming malware |
| `jq` missing | **block**, rather than guessing |

Halting builds on a broken vendor release is the lesser evil. The deliberate remedy is to unset `SOCKET_SECURITY_API_TOKEN`, which already skips the scan visibly, rather than widening the allowlist — and the error message says so.

OSV's `MAL-*` gate is moved to its own variable. Sharing one `rc` meant clearing a Socket transport failure would also have cleared a real OSV malware finding.

## Verification

The step was extracted from the workflow and run against stubbed outcomes:

| Case | exit | | Case | exit |
|---|---|---|---|---|
| clean pass | 0 | | 413 payload | 1 |
| 503 | 0 | | 422 unprocessable | 1 |
| 429 | 0 | | 404 wrong org | 1 |
| | | | 401 revoked token | 1 |
| | | | CLI crash (no status) | 1 |
| | | | policy verdict | 1 |
| | | | package named `econnreset` | 1 |
| | | | forged envelope on stderr | 1 |
| | | | empty output | 1 |
| | | | `jq` absent | 1 |

An OSV `MAL-*` finding fails the step regardless of how Socket is classified.

Reviewed twice with a cross-model reviewer; the report-grep bypass, the false-malware messaging, and the fail-open wildcard were each found and fixed in that order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second commit: the crash was upstream, and the scan never ran

The diagnostic build (`push=false`) confirmed the failure is **deterministic** — three runs, fresh runners, identical. goss passed 4/4, so the image was never the problem.

**Root cause:** `socket@1.1.152` declares only `@socketsecurity/socket-patch`, yet its bundle `require()`s `form-data` when it uploads a manifest. The dependency is neither declared nor bundled:

```
$ npm view socket@1.1.152 dependencies
{ "@socketsecurity/socket-patch": "2.0.0" }
```

So the scan dies the moment it has something to send. Apps whose scan finds zero files never upload and never see it — which is why this looked app-specific rather than repo-wide.

### Fix

- **Install `form-data` as a sibling of `socket`**, so node resolves it by walking up from `socket/dist/`. Verified with `require.resolve` against the real installed tree.
- **Pin the CLI, replacing `npx -y socket`.** That fetched whatever was tagged `latest` at build time — unpinned third-party code executing in a job that pushes production images, which is the thing this step exists to guard against, and why one bad upstream release could break every Node build here at once.

`2.x` is published but deprecated upstream as *"bad build"*, so 1.1.152 is the only usable release and the pin must be bumped by hand. Deliberate bump over silent break.

A failed CLI install is classified as "could not scan", not as a finding.

### Not yet proven

Module resolution is verified locally. The scan **completing** is not — the crash occurs after auth, so local reproduction stops at a 401 without a valid org token. A `harbor-relay` build on this branch is the real test.

The upstream packaging bug is worth reporting to Socket separately.
