### PR TITLE
fix(ci): resolve StremThru's server release, not the newest monorepo tag

### DIFF
--- a/apps/stremthru/ci/latest.sh
+++ b/apps/stremthru/ci/latest.sh
@@ -1,4 +1,32 @@
 #!/usr/bin/env bash
-version=$(curl -sX GET https://api.github.com/repos/MunifTanjim/stremthru/releases/latest --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '. | .tag_name')
+set -euo pipefail
+
+repo="MunifTanjim/stremthru"
+
+headers=(-H "Accept: application/vnd.github+json")
+if [[ -n "${TOKEN:-${GITHUB_TOKEN:-}}" ]]; then
+  headers+=(-H "Authorization: Bearer ${TOKEN:-${GITHUB_TOKEN:-}}")
+fi
+
+# This repo publishes SDK releases (sdk-py-*, sdk-js-*) alongside the server,
+# so `releases/latest` is not necessarily a StremThru server release. Today it
+# happens to be one; the next SDK release would resolve to a tag that clones
+# cleanly and builds a tree that is not the server, silently rolling the
+# deployed server back.
+#
+# Take the newest published release whose tag is a server version (N.N.N).
+version=""
+for page in 1 2 3; do
+  version=$(curl -fsSL "${headers[@]}" "https://api.github.com/repos/${repo}/releases?per_page=100&page=${page}" \
+    | jq --raw-output '[.[] | select(.draft == false and .prerelease == false) | .tag_name | select(test("^[0-9]"))] | first // empty')
+  if [[ -n "${version}" ]]; then
+    break
+  fi
+done
+
+if [[ -z "${version}" ]]; then
+  echo "ERROR: no ${repo} server release (N.N.N) in the 300 most recent releases" >&2
+  exit 1
+fi
 
 printf "%s" "${version}"


### PR DESCRIPTION
> **Scope reduced.** This branch originally fixed both `aiostreams` and `stremthru`. 563153a4 ("fix: harden remux and aiostreams release tracking") landed the aiostreams half on main concurrently, so only the stremthru fix remains here.

`apps/stremthru/ci/latest.sh` takes GitHub's `releases/latest` verbatim, but `MunifTanjim/stremthru` publishes SDK releases (`sdk-py-*`, `sdk-js-*`) from the same repo as the server.

Today `releases/latest` is the server (`0.103.2`) purely by ordering. The next SDK release would resolve to a tag that clones cleanly and builds a tree that is not the server — silently rolling the deployed server back, under a version label that looks nothing like a server version. This is the same class of bug that was already *live* for aiostreams, where `releases/latest` was `seanime-extensions-v0.10.1` and the 2026-08-11 image was built from it.

## The fix

Take the newest published non-draft, non-prerelease release whose tag is a server version (`^[0-9]`). Exit non-zero with a message when nothing matches, so the existing *"refusing to build a null-tagged image"* guard in `action-image-build.yaml` fires rather than shipping garbage.

Follows the conditional-header idiom already used by `apps/grimmory`, `apps/nzbdav` and `apps/mediastorm`: `set -euo pipefail`, `curl -fsSL`, and an Authorization header only when `${TOKEN:-${GITHUB_TOKEN:-}}` is non-empty, so it still works unauthenticated outside CI.

## Verification

On top of current main, via `./.github/scripts/upstream.sh` as CI calls it, and directly:

| mode | result |
|---|---|
| with `TOKEN` | `0.103.2` |
| `TOKEN` unset | `0.103.2` |
| `TOKEN` empty | `0.103.2` |
| bogus `TOKEN` | exit≠0, empty stdout |

Main's aiostreams resolver still returns `v2.33.1`, unaffected by this change.

## Note on main's aiostreams variant

It resolves page 1 only, where mine paginated. That has ample headroom and I deliberately left it alone rather than churn a file that was just fixed: `v2.33.1` sits at index 10 of the 100 most recent releases against a ~4/day nightly cadence, and if an app release ever fell off page 1 the result is a loud build failure, not a silent rollback.

Reviewed cross-model; one P2 found and fixed (an earlier revision used a bare `${TOKEN}` under `set -u`, which aborted outside CI where the previous script degraded to an empty bearer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)