### PR TITLE
feat(palantir): register the tenant-usage exporter

### DIFF
--- a/apps/palantir/ci/latest.sh
+++ b/apps/palantir/ci/latest.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+version=$(curl -sX GET https://api.github.com/repos/elfhosted/palantir/releases/latest --header "Authorization: Bearer ${ZURG_GH_CREDS}" | jq --raw-output '. | .tag_name')
+printf "%s" "${version}"

--- a/apps/palantir/metadata.json
+++ b/apps/palantir/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "palantir",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Registers [`elfhosted/palantir`](https://github.com/elfhosted/palantir) for image builds, mirroring `apps/gandalf`.

Palantír aggregates Traefik's per-IngressRoute counters into per-tenant, per-app usage metrics. It exists so the `traefik` PodMonitor's `(.+-)?aa-.+` drop rule can stay exactly as it is — keeping those raw series would mean ~21,700 tenant IngressRoutes × status codes × up to 54 DaemonSet pods in the shared Prometheus. Palantír sums across pods, methods, protocols and status codes before exposing anything, so the whole fleet costs ~65k series from one scrape target.

## What's here

- `apps/palantir/metadata.json` — app `palantir`, channel `main`, `linux/amd64`, tests disabled (identical to `apps/gandalf` other than the name)
- `apps/palantir/ci/latest.sh` — resolves the latest release tag from the GitHub API

## Companion changes

- `elfhosted/containers-private` — `apps/palantir/Dockerfile` (the cloner + Go build stages)
- `elfhosted/infra` — namespace, RBAC, Deployment, Service, PodMonitor per cluster, plus the cross-cluster aggregation wiring

## Ordering

`elfhosted/palantir` has no release tag yet, so `latest.sh` returns `null` until release-please cuts v0.1.0. Merging this before then is harmless — the build just has nothing to resolve — but the image won't exist until that release lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)