### PR TITLE
feat(sabnzbd): add proxy channel to the release matrix

### DIFF
--- a/apps/sabnzbd/metadata.json
+++ b/apps/sabnzbd/metadata.json
@@ -12,6 +12,17 @@
         "enabled": true,
         "type": "web"
       }
+    },
+    {
+      "name": "proxy",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": false,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
     }
   ]
 }


### PR DESCRIPTION
Pairs with **elfhosted/containers-private#145** — needs both to land.

## Problem

The `nzb-proxy` sidecar in **aiostreams, mediastorm, nzbdav, usenetstreamer, usenetultimate** runs `ghcr.io/elfhosted/sabnzbd-proxy`, but no `proxy` channel has ever existed here. That package has only ever come from manual runs — last built 2026-06-17 — so renovate has no newer tag to bump and all five sidecars are frozen at 5.0.4 while the main sabnzbd pin moves on.

## Change

Declares the `proxy` channel, exactly as `apps/nzbhydra2/metadata.json` has since `5e90d209`. `action-image-build.yaml` prefers `apps/<app>/<channel>/Dockerfile` over `apps/<app>/Dockerfile`, so declaring the channel here is enough to route the build to `apps/sabnzbd/proxy/Dockerfile` in containers-private and tag it `sabnzbd-proxy:<version>`.

`ci/latest.sh` needs no change — it ignores the channel argument and returns upstream's latest release, so the proxy channel tracks the same version as main. That's the nzbhydra2 behaviour too (`nzbhydra2-proxy:8.9.0` matches stable).

Tests are **enabled** here, unlike nzbhydra2's proxy channel. The variant serves `/replay`, so goss can assert the patch actually applied rather than merely that a process is up.

`cue vet --schema '#Spec' ./apps/sabnzbd/metadata.json ./metadata.rules.cue` passes.

## Why the companion PR is required

`containers-private/apps/sabnzbd/metadata.json` currently declares this app's channel as `stable` while this file declares `main`, and the build job overlays containers-private over `apps/` **before** reading metadata. So `jq 'select(.name == "main")'` matches nothing, `chan_stable` comes back empty, and every scheduled build takes the non-stable tagging path and publishes to `ghcr.io/elfhosted/sabnzbd-main`.

That package is real and holds `5.1.0` (built today), while `ghcr.io/elfhosted/sabnzbd` has been stuck on 5.0.4 since June. Since the matrix compares upstream against the `sabnzbd` package, the mismatch never converges — **sabnzbd has been rebuilding every hour** and the empty lookup also silently skips its goss tests. The companion PR deletes that stray file, which is why nzbhydra2 (no metadata.json in containers-private) was never affected.

Landing this alone would still work — an unmatched `proxy` lookup falls through to the non-stable path and coincidentally produces the right `sabnzbd-proxy` tag — but goss would be skipped and it would be right by accident. Land both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)