### PR TITLE
feat(minecraft): add Minecraft (Java Edition) container metadata

### DIFF
--- a/apps/minecraft/ci/latest.sh
+++ b/apps/minecraft/ci/latest.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# VERSION here is the itzg/docker-minecraft-server image release (CalVer, e.g.
+# 2026.8.0), NOT the Minecraft version. The Minecraft version and the server
+# flavour (Paper/Fabric/Forge) are runtime settings, because the server jar is
+# downloaded and assembled at boot rather than baked into the image. See the
+# Dockerfile for why that distinction is load-bearing rather than incidental.
+version=$(curl -fsSL -X GET "https://api.github.com/repos/itzg/docker-minecraft-server/releases/latest" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.tag_name')
+version="${version#*v}"
+printf "%s" "${version}"

--- a/apps/minecraft/metadata.json
+++ b/apps/minecraft/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "minecraft",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Public half of the Minecraft image for [EEP #176](https://github.com/elfhosted/enhancements/issues/176). The Dockerfile and goss config live in elfhosted/containers-private#153, as usual.

**Merge order matters.** `action-image-build.yaml` checks out containers-private with no `ref:`, so it builds from that repo's default branch regardless of which branch the workflow runs on. containers-private#153 has to land on `main` before `Release: Manual` here can produce an image.

## `VERSION` is not the Minecraft version

`ci/latest.sh` returns the `itzg/docker-minecraft-server` image release (CalVer, e.g. `2026.8.0`). The Minecraft version and the server flavour are runtime settings, because the server jar is downloaded and assembled at boot rather than baked in — Mojang's EULA bars distributing modified server software, and Paper ships a runtime patcher for exactly that reason. Full rationale is at the top of the Dockerfile.

## `tests.type` is `web` and Minecraft has no HTTP surface

That field does not mean what it says. `cli` makes CI replace the container command with `tail -f /dev/null`, so the server would never start and every goss assertion would be vacuous. `web` is how you ask for the real entrypoint. Terraria does the same thing for the same reason.

Tests are enabled and pass: 13 checks, ~30s, asserting a real server-list ping via `mc-monitor` plus that online-mode actually landed in `server.properties`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)