### PR TITLE
feat(foundryvtt): add Foundry Virtual Tabletop to the catalogue

### DIFF
--- a/apps/foundryvtt/ci/latest.sh
+++ b/apps/foundryvtt/ci/latest.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Foundry Virtual Tabletop is proprietary software distributed by Foundry Gaming LLC.
+# It is NOT published on GitHub and there is no public releases API to poll, so this
+# cannot auto-detect upstream versions the way every other app here does.
+#
+# The image we build does not contain Foundry itself. It is a launcher: Foundry is
+# downloaded at container start using the tenant's own licence key / timed download
+# URL (see the Dockerfile). The version below therefore tracks OUR launcher, not
+# Foundry, and is bumped by hand when the launcher changes.
+#
+# The Foundry version a tenant actually runs is whatever their timed download URL
+# points at, which is decided on foundryvtt.com, not here. There is no version
+# selector in this image.
+printf "%s" "1.0.0"

--- a/apps/foundryvtt/metadata.json
+++ b/apps/foundryvtt/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "foundryvtt",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "cli"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Public half of the Foundry VTT launcher (EEP #168). Dockerfile and goss live in `containers-private` (elfhosted/containers-private#198).

- `metadata.json` — single `main` channel, `linux/amd64`. Tests are now **enabled** as `type: cli`: the application itself can never run in CI (no Foundry credential survives to job time), but the launcher's contract can, and that is where the bugs turned out to be.
- `ci/latest.sh` — static `1.0.0` by design. Foundry is proprietary with no releases API, and this version tracks *our launcher*, not Foundry.

Also removes a comment claiming the Foundry version is selected at runtime via `FOUNDRY_VERSION`. That variable exists in no repo and never did; the version a tenant runs is whatever their download URL points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)