### PR TITLE
feat(parent): add the game-server panel sidecar image metadata

### DIFF
--- a/apps/parent/ci/latest.sh
+++ b/apps/parent/ci/latest.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# `parent` is our own code and has no upstream to track, so the version is
+# declared here and bumped by hand on release. Renovate has nothing to watch.
+#
+# Bump this when apps/parent/ changes in containers-private, otherwise the tag
+# stays put across rebuilds and imagePullPolicy: IfNotPresent leaves nodes that
+# already cached it running the OLD build forever. The chart pins the digest for
+# exactly that reason, but a moving tag is still the clearer signal.
+printf "%s" "1.0.0"

--- a/apps/parent/metadata.json
+++ b/apps/parent/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "parent",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Public half of the `parent` sidecar. Dockerfile and goss live in containers-private (elfhosted/containers-private#202) per the usual split; CI overlays them.

No upstream to track, so `latest.sh` declares the version and is bumped by hand when `apps/parent/` changes in containers-private. Renovate has nothing to watch here.

New app, so the image needs a manual `Release` run to build the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)