### PR TITLE
chore(parent): 1.5.1 -> 1.6.0 (bedrock name handling)

### DIFF
--- a/apps/parent/ci/latest.sh
+++ b/apps/parent/ci/latest.sh
@@ -6,4 +6,4 @@
 # stays put across rebuilds and imagePullPolicy: IfNotPresent leaves nodes that
 # already cached it running the OLD build forever. The chart pins the digest for
 # exactly that reason, but a moving tag is still the clearer signal.
-printf "%s" "1.5.1"
+printf "%s" "1.6.0"


### PR DESCRIPTION
elfhosted/containers-private#218 landed the Floodgate prefix handling but **no version bump followed it**, so the built image is still 1.5.1 and the live panel shows `.FunkyPenguinNZ` rather than `FunkyPenguinNZ`. Confirmed against a real Bedrock client on funkypenguin just now.

After merge this needs a `Release: Manual` run for `parent`, then the new digest pinned in myprecious.

Generated with Claude Code