### PR TITLE
chore(parent): 1.6.0 -> 1.6.1 (heal split playtime history)

### DIFF
--- a/apps/parent/ci/latest.sh
+++ b/apps/parent/ci/latest.sh
@@ -6,4 +6,4 @@
 # stays put across rebuilds and imagePullPolicy: IfNotPresent leaves nodes that
 # already cached it running the OLD build forever. The chart pins the digest for
 # exactly that reason, but a moving tag is still the clearer signal.
-printf "%s" "1.6.0"
+printf "%s" "1.6.1"


### PR DESCRIPTION
Picks up containers-private#219.

Live presence was already correct after 1.6.0, but ledger rows written before it stayed under the Floodgate-prefixed name, so a parent saw one child as two people and neither playtime total was the real one. Names are now normalised on read as well as write.

Generated with Claude Code