### PR TITLE
chore(parent): 1.6.1 -> 1.7.0 (allowlist UI and access mode)

### DIFF
--- a/apps/parent/ci/latest.sh
+++ b/apps/parent/ci/latest.sh
@@ -6,4 +6,4 @@
 # stays put across rebuilds and imagePullPolicy: IfNotPresent leaves nodes that
 # already cached it running the OLD build forever. The chart pins the digest for
 # exactly that reason, but a moving tag is still the clearer signal.
-printf "%s" "1.6.1"
+printf "%s" "1.7.0"


### PR DESCRIPTION
Picks up containers-private#220 and #221 — the whitelist security fix, the allowlist UI, and the parent-chosen access mode that makes onboarding Bedrock players possible at all.

Generated with Claude Code