### PR TITLE
feat(harbor-feed): builders for Harbor's consensus feeds

### DIFF
--- a/apps/harbor-feed/ci/latest.sh
+++ b/apps/harbor-feed/ci/latest.sh
@@ -26,15 +26,39 @@ repo="harborstremio/harbor-hosted"
 component="harbor-feed"
 auth_header="Authorization: Bearer ${ZURG_GH_CREDS}"
 
+# PAGINATED. harbor-hosted is a release-please monorepo cutting one tag per
+# component, and tag order is neither date- nor semver-guaranteed, so a single
+# per_page=100 page will eventually stop containing harbor-feed's tags and this
+# would silently pin a stale version.
+tags=""
+page=1
+while [ "${page}" -le 10 ]; do
+  chunk="$(
+    curl -fsSL -H "${auth_header}" \
+      "https://api.github.com/repos/${repo}/tags?per_page=100&page=${page}" \
+    | jq -r '.[].name' 2>/dev/null
+  )"
+  [ -z "${chunk}" ] && break
+  tags="${tags}${chunk}
+"
+  page=$((page + 1))
+done
+
 version="$(
-  curl -fsSL -H "${auth_header}" \
-    "https://api.github.com/repos/${repo}/tags?per_page=100" \
-  | jq -r --arg c "${component}-v" '.[].name | select(startswith($c))' \
+  printf '%s' "${tags}" \
+  | grep -E "^${component}-v[0-9]+\.[0-9]+\.[0-9]+$" \
   | sed "s/^${component}-v//" \
-  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
   | sort -V \
   | tail -n1 \
   | sed "s/^/${component}-v/"
 )"
+
+# FAIL LOUDLY. Without this the pipeline's failure is invisible: a bad
+# credential or an API blip prints nothing and exits 0. The build workflow does
+# refuse a null tag, but its message says only "resolved empty" and not why.
+if [ -z "${version}" ]; then
+  echo "no ${component}-v* tag found in ${repo} (credential, API, or genuinely none)" >&2
+  exit 1
+fi
 
 printf '%s' "${version}"

--- a/apps/harbor-feed/ci/latest.sh
+++ b/apps/harbor-feed/ci/latest.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# harbor-feed: the six consensus-feed builders (home hero Top 10, anime hero,
+# award winners, people rank) that generate the static JSON harbor.site serves.
+#
+# Source: https://github.com/harborstremio/harbor-hosted (PRIVATE), at
+# services/harbor-feed/src.
+#
+# WHY THIS EXISTS: these generators were left on the retiring VPS when the apex
+# static origin moved to Kubernetes, so the box kept producing fresh files that
+# no longer reached the edge and every feed has served a frozen copy since
+# 2026-07-31. Nothing rebuilds them on this side until this image does.
+#
+# ZURG_GH_CREDS is the credential, as for every other Harbor image.
+#
+# EMITTED VERBATIM, component prefix and all: this value is BOTH the --build-arg
+# VERSION the Dockerfile checks out AND the image tag, so it has to be a valid
+# git ref and a legal Docker tag at once. release-please cuts
+# harbor-feed-v<semver> from harbor-hosted, which satisfies both.
+#
+# Renovate reads this shape through the component-regex rule in infra's
+# renovate.json5; harbor-feed must be added to that rule's matchPackageNames, or
+# it will silently never be bumped.
+set -uo pipefail
+
+repo="harborstremio/harbor-hosted"
+component="harbor-feed"
+auth_header="Authorization: Bearer ${ZURG_GH_CREDS}"
+
+version="$(
+  curl -fsSL -H "${auth_header}" \
+    "https://api.github.com/repos/${repo}/tags?per_page=100" \
+  | jq -r --arg c "${component}-v" '.[].name | select(startswith($c))' \
+  | sed "s/^${component}-v//" \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | tail -n1 \
+  | sed "s/^/${component}-v/"
+)"
+
+printf '%s' "${version}"

--- a/apps/harbor-feed/metadata.json
+++ b/apps/harbor-feed/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "harbor-feed",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "cli"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Harbor's home hero Top 10, anime hero, award winners and people rank have served a **frozen 2026-07-31 copy** since their generators were stranded on the retiring VPS. This is the image that runs them here. Infra PR (secret, PVC, CronJobs) links from the companion.

`node:20` + `python3`, no npm or pip dependencies — upstream uses only stdlib. `s5cmd` and `curl` are ours, pinned by version **and checksum** (verified against the published checksums file and independently recomputed), because this runs with credentials for the bucket that serves a public site.

## The wrapper is the interesting part

The builders write to `/var/www/harbor-apex` and purge Cloudflare themselves — correct on the box, where that path *was* the nginx root. Here it's an emptyDir nobody serves, so purging would happen **before** the bytes reached the bucket, Cloudflare would re-cache the old object, and nothing would purge again. `feed-run.sh` does hydrate → build → publish → purge, and passes the Cloudflare credentials as `FEED_CF_*` with the upstream names unset, because the builder is a child process and would otherwise inherit them.

**The web root is input as well as output** — the thing most easily missed. `build-anime-hero.js` reads `anime-hero-art.json` for art overrides inside a `try/catch` that yields `{}` when absent, and `update-anime-hero-art.py` *merges* into its own previous output with no minimum-size guard. On a bare emptyDir both silently degrade every run while staying green. `FEED_HYDRATE` pulls them from the bucket first; a 404 is a genuine first run, anything else is fatal.

It also refuses to publish a failed build, or one that wrote nothing — uploading nothing then purging would blank the feed at the edge.

## Found in cross-model review

- `HERO_OUT` defaults to `/app/anime.json`, **outside** the published root, so the anime-hero job would have failed every run. Upstream's README says the defaults already target the apex root; for that builder they don't. Pinned in the image.
- The purge wrote its response to `/tmp`, which fails under `readOnlyRootFilesystem`; the status check would never match 200 and the script would exit 0 — a purge that never happens, with green jobs. Captured in a variable now.
- `HARBOR_S3_PREFIX` without a trailing slash published to `<prefix>site/`. Green, and stale forever. Normalised.
- Cloudflare caps purge-by-URL at 30; one oversized POST purges nothing. Batched — verified 65 → 30/30/5.
- `FEED_REQUIRE_CACHE` refuses to cold-rebuild rank against TMDB when the cache PVC is missing, which `build-rank.js` cannot itself distinguish from a cold start.
- `latest.sh` now paginates (release-please monorepo tags will eventually fall off page one) and fails loudly instead of printing nothing and exiting 0.

## Verification

goss **31/31** against a real build at `harbor-feed-v0.1.0`. Wrapper tested behaviourally: publishes then purges; the builder cannot see `CF_PURGE_TOKEN` even when set upstream; failed build doesn't publish; empty output doesn't publish; failed upload doesn't purge; missing CF creds warn rather than fail; prefix normalises both ways; hydrate tolerates 404 and fails on anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)