### PR TITLE
feat(bookorbit): add image metadata and version detection

### DIFF
--- a/apps/bookorbit/ci/latest.sh
+++ b/apps/bookorbit/ci/latest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+version=$(curl -sX GET "https://api.github.com/repos/bookorbit/bookorbit/releases/latest" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.tag_name')
+version="${version#*v}"
+printf "%s" "${version}"

--- a/apps/bookorbit/metadata.json
+++ b/apps/bookorbit/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "bookorbit",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "cli"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds the public half of the BookOrbit image for [EEP #177](https://github.com/elfhosted/enhancements/issues/177). The Dockerfile, entrypoint and goss suite are in the matching `containers-private` PR.

BookOrbit is an AGPL-3.0 library and reading platform for ebooks, PDFs, audiobooks and comics, with web readers, OPDS, and Kobo/KOReader sync.

## Why tests are `cli` rather than `web`

BookOrbit runs its database migration before starting the server, so it cannot reach a listening state without PostgreSQL and a `web` test could never pass standalone. The goss suite asserts the image contract instead, which CI exercises by running the container as `tail -f /dev/null`. 33 assertions, verified green locally with dgoss.

## Merge order

`ghcr.io/elfhosted/bookorbit:2.6.0` does not exist yet, and the myprecious chart enables this app on funkypenguin. This needs to merge **and** have `Release: Manual` triggered before the tenant reconciles, since a push alone only runs CodeQL.

`icons` and `homer` also need a manual release, for the PNG added in the private PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)