### PR TITLE
feat(koito,maloja): add two music scrobblers for EEP #179 and #180

### DIFF
--- a/apps/koito/ci/latest.sh
+++ b/apps/koito/ci/latest.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Koito tags GitHub releases as vX.Y.Z and publishes matching Docker Hub tags
+# with the "v" retained (gabehf/koito:v0.3.2). We strip the "v" here because the
+# emitted value becomes our own image tag, and the Dockerfile puts it back when
+# it resolves the upstream base.
+#
+# Do NOT switch this to the "dev" tag or to /tags: upstream marks the project
+# unstable and warns that main can be unusable, so only cut releases are safe.
+version=$(curl -L -sX GET "https://api.github.com/repos/gabehf/Koito/releases/latest" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.tag_name')
+version="${version#*v}"
+printf "%s" "${version}"

--- a/apps/koito/metadata.json
+++ b/apps/koito/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "koito",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}

--- a/apps/maloja/ci/latest.sh
+++ b/apps/maloja/ci/latest.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Maloja publishes git tags but NO GitHub releases, so /releases/latest returns
+# null here and this has to read /tags. Tag order from that endpoint is not
+# semver-sorted, hence the explicit sort -V rather than taking .[0].
+version=$(curl -L -sX GET "https://api.github.com/repos/krateng/maloja/tags?per_page=100" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.[].name' | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+version="${version#*v}"
+printf "%s" "${version}"

--- a/apps/maloja/metadata.json
+++ b/apps/maloja/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "maloja",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds image metadata and version detection for two music scrobblers, per [EEP #179 (Koito)](https://github.com/elfhosted/enhancements/issues/179) and [EEP #180 (Maloja)](https://github.com/elfhosted/enhancements/issues/180).

Both record what a music player plays and turn it into listening history. They overlap deliberately: Koito is the better-looking newer one, Maloja the older one that speaks more scrobble dialects and cleans up metadata. Each app's docs page says plainly when the other is the better choice.

## Version detection

`koito/ci/latest.sh` reads GitHub releases and strips the `v`; upstream's Docker Hub tags keep it, so the Dockerfile puts it back. It deliberately does **not** track the `dev` tag or `/tags`, because upstream marks the project unstable and warns main can be unusable.

`maloja/ci/latest.sh` reads `/tags` rather than `/releases/latest`, because upstream publishes git tags and no GitHub releases at all, so `/releases/latest` returns null. Tag order from that endpoint is not semver-sorted, hence the `sort -V`.

Both verified to resolve locally: `0.3.2` and `3.2.6`.

## Licences

Read from the actual LICENSE files, not the sidebar. Koito is MIT. Maloja is GPL-3.0 and is built from the unmodified upstream tree with no patches, so the Corresponding Source is exactly upstream at the tagged version. Neither repo carries a `COMMERCIAL*`/`EE` side-file.

## Note for the first build

Neither image has been built by CI yet, so this needs a **Release: Manual** run for `koito` and `maloja` (channel `main`, push `true`) before the chart can deploy. The chart ships both apps `enabled: false`, so nothing breaks in the meantime.

Companion PRs: containers-private (Dockerfiles + goss + icons), myprecious (chart), docs, tenants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)