### PR TITLE
feat(whisperx): image metadata for the shared ASR service

### DIFF
--- a/apps/whisperx/ci/latest.sh
+++ b/apps/whisperx/ci/latest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+version=$(curl -sX GET "https://api.github.com/repos/ahmetoner/whisper-asr-webservice/releases/latest" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.tag_name')
+version="${version#*v}"
+printf "%s" "${version}"

--- a/apps/whisperx/metadata.json
+++ b/apps/whisperx/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "whisperx",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds `apps/whisperx/` so CI can build the GPU ASR image behind the new shared transcription service on `.coffee`.

Tracks `ahmetoner/whisper-asr-webservice` releases (currently v1.10.0). amd64 only — the runtime is a CUDA image and the only GPUs that can run it are the T4s on `.coffee`.

Dockerfile, the OpenAI shim, and goss live in `containers-private` (elfhosted/containers-private#feat-whisperx-service). Infra manifests in elfhosted/infra.

Needs `Release: Manual` for the first build — a push alone only runs CodeQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)