### PR TITLE
feat(palworld): register image build + bump parent to 1.14.0 (EEP #183)

### DIFF
--- a/apps/palworld/ci/latest.sh
+++ b/apps/palworld/ci/latest.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# VERSION here is the thijsvanloef/palworld-server-docker image release (e.g.
+# 2.7.2, published to Docker Hub as v2.7.2 -- the Dockerfile re-adds the v).
+# It is NOT the Palworld version: the game server is downloaded from Steam at
+# boot, and whatever Steam serves is the only version current clients can join,
+# so there is nothing to pin. See the Dockerfile for why that distinction is
+# load-bearing rather than incidental.
+version=$(curl -fsSL -X GET "https://api.github.com/repos/thijsvanloef/palworld-server-docker/releases/latest" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.tag_name')
+version="${version#*v}"
+printf "%s" "${version}"

--- a/apps/palworld/metadata.json
+++ b/apps/palworld/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "palworld",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}

--- a/apps/parent/ci/latest.sh
+++ b/apps/parent/ci/latest.sh
@@ -6,4 +6,4 @@
 # stays put across rebuilds and imagePullPolicy: IfNotPresent leaves nodes that
 # already cached it running the OLD build forever. The chart pins the digest for
 # exactly that reason, but a moving tag is still the clearer signal.
-printf "%s" "1.13.0"
+printf "%s" "1.14.0"


### PR DESCRIPTION
Companion to elfhosted/containers-private#253.

- `apps/palworld`: tracks thijsvanloef/palworld-server-docker releases (Docker Hub tags carry a `v`; latest.sh emits the bare version, the private Dockerfile re-adds it). linux/amd64, goss enabled (type "web").
- `apps/parent`: 1.13.0 → 1.14.0 for the new palworld adapter (hand-declared version, no upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)