### PR TITLE
fix(maloja): patch upstream scrobble corruption, and build it in the open

### DIFF
--- a/apps/maloja/Dockerfile
+++ b/apps/maloja/Dockerfile
@@ -1,5 +1,8 @@
-# Maloja is GPL-3.0, and THAT IS WHY THIS FILE LIVES IN THE PUBLIC REPO while
-# every other app's Dockerfile lives in containers-private.
+# THE RULE: app builds live in containers-private. This repo carries a Dockerfile
+# or a patch series ONLY where the licence or collaborative work requires it.
+# Other public copies you may find here are historical drift, not permission.
+#
+# Maloja meets the test: it is GPL-3.0 AND we patch it.
 #
 # The image is built from upstream's tree at ${VERSION} plus the patch series in
 # ./patches/. Distributing a modified GPL work means offering the Corresponding
@@ -7,10 +10,10 @@
 # these patches, plus this Dockerfile, is the complete recipe. Keeping the
 # Dockerfile private while shipping a patched binary would not satisfy that.
 #
-# So, unlike everywhere else in this estate: patches here are FINE, and both
-# they and this file must stay public. If you move this back to
-# containers-private, you must also drop ./patches/ and rebuild from an
-# unmodified tree.
+# So for THIS app, patches are fine and both they and this file must stay public.
+# That licence is the whole justification: drop ./patches/ and rebuild from an
+# unmodified tree and this belongs back in containers-private. Do not cite this
+# file as a precedent for making some other app's build public.
 #
 # ci/goss.yaml stays in containers-private, matching the usual split (ci/latest.sh
 # public, ci/goss.yaml private). It is test configuration, not part of the

--- a/apps/maloja/Dockerfile
+++ b/apps/maloja/Dockerfile
@@ -1,0 +1,116 @@
+# Maloja is GPL-3.0, and THAT IS WHY THIS FILE LIVES IN THE PUBLIC REPO while
+# every other app's Dockerfile lives in containers-private.
+#
+# The image is built from upstream's tree at ${VERSION} plus the patch series in
+# ./patches/. Distributing a modified GPL work means offering the Corresponding
+# Source, so the modification has to be public: upstream at v${VERSION}, plus
+# these patches, plus this Dockerfile, is the complete recipe. Keeping the
+# Dockerfile private while shipping a patched binary would not satisfy that.
+#
+# So, unlike everywhere else in this estate: patches here are FINE, and both
+# they and this file must stay public. If you move this back to
+# containers-private, you must also drop ./patches/ and rebuild from an
+# unmodified tree.
+#
+# ci/goss.yaml stays in containers-private, matching the usual split (ci/latest.sh
+# public, ci/goss.yaml private). It is test configuration, not part of the
+# Corresponding Source.
+#
+# Why build from source when upstream publishes krateng/maloja on Docker Hub:
+# that image is lsiobase/alpine driven by s6-overlay, whose init must start as
+# root in order to chown and then s6-setuidgid down to "abc" (upstream even
+# defaults PUID/PGID to 0). ElfHosted runs tenant pods non-root with
+# readOnlyRootFilesystem, which s6-overlay cannot survive. Installing the same
+# pip package ourselves and exec'ing it directly as elfie sidesteps s6 entirely.
+#
+# The python floor is not a preference: pyproject.toml pins
+# requires-python = "==3.12.*", so 3.13 refuses to install and any bump here
+# must be checked against upstream first.
+
+FROM public.ecr.aws/docker/library/alpine:3.21 AS cloner
+ARG VERSION
+
+RUN apk add --no-cache git
+RUN git clone --depth 1 --branch "v${VERSION}" https://github.com/krateng/maloja.git /source
+
+
+FROM public.ecr.aws/docker/library/python:3.12-alpine AS builder
+
+# setproctitle, psutil, lru-dict and python-datauri have no musl wheels on
+# PyPI, so they are compiled here and only the finished venv is copied forward.
+# hadolint ignore=DL3018
+RUN apk add --no-cache \
+      gcc g++ musl-dev python3-dev libffi-dev linux-headers \
+      libxml2-dev libxslt-dev git
+
+COPY --from=cloner /source /source
+
+# Patch series is applied in the BUILDER stage, so the installed package carries
+# it -- applying it to /source alone would be a no-op once pip copies the tree.
+# git apply is used rather than patch(1) so a context mismatch fails the build
+# loudly instead of fuzzing the hunk into the wrong place.
+COPY apps/maloja/patches/*.patch /patches/
+RUN cd /source && for p in /patches/*.patch; do echo "Applying $p"; git apply --verbose "$p" || exit 1; done
+
+RUN python3 -m venv /venv && \
+    /venv/bin/pip install --no-cache-dir --upgrade pip wheel && \
+    /venv/bin/pip install --no-cache-dir /source
+
+
+FROM public.ecr.aws/docker/library/python:3.12-alpine
+ARG VERSION
+ARG APP_REVISION
+
+LABEL org.opencontainers.image.title="Maloja" \
+      org.opencontainers.image.description="Maloja: a music scrobble database with listening statistics and charts." \
+      org.opencontainers.image.source="https://github.com/krateng/maloja" \
+      org.opencontainers.image.documentation="https://docs.elfhosted.com/app/maloja/" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$APP_REVISION \
+      org.opencontainers.image.licenses="GPL-3.0"
+
+# libmagic backs python-magic (image type sniffing); vips is the optional
+# thumbnailer; tzdata is needed because Maloja's weekly/yearly charts are
+# timezone-bucketed and would otherwise all land in UTC.
+# hadolint ignore=DL3018
+RUN apk add --no-cache libmagic tzdata tini vips && \
+    addgroup -S elfie --gid 568 && \
+    adduser -S elfie -G elfie --uid 568 && \
+    mkdir -p /config && \
+    chown -R elfie:elfie /config
+
+COPY --from=builder /venv /venv
+
+# One directory for everything: with DATA_DIRECTORY set, Maloja derives config,
+# state, cache and logs from it (pkg_global/conf.py), so /config holds the
+# scrobble DB, the auth file, the API keys and the import/ drop folder.
+ENV MALOJA_DATA_DIRECTORY=/config \
+    MALOJA_CONTAINER=yes \
+    PYTHONUNBUFFERED=1 \
+    PATH="/venv/bin:${PATH}" \
+    HOME=/tmp
+
+# MALOJA_SKIP_SETUP is not optional. Without it, first start drops into an
+# interactive prompt for API keys and a password, gets EOFError against a
+# container's closed stdin, and exits.
+ENV MALOJA_SKIP_SETUP=yes
+
+# Read by elf-entrypoint.sh, NOT by Maloja: doreah's config loader ignores any
+# MALOJA_* name it does not recognise (Configuration.load_environment), so this
+# is safe to sit alongside the real settings. The chart overrides it; the
+# default here keeps a bare `docker run` of this image usable.
+ENV MALOJA_INITIAL_PASSWORD=changemeelfie
+
+COPY apps/maloja/elf-entrypoint.sh /usr/local/bin/elf-entrypoint.sh
+RUN sed -i 's/\r$//' /usr/local/bin/elf-entrypoint.sh && \
+    chmod +x /usr/local/bin/elf-entrypoint.sh
+
+USER 568
+
+EXPOSE 42010
+
+# ENTRYPOINT is the wrapper and the real command is CMD, so that CI's goss run
+# (which overrides the command with `tail -f /dev/null`) still executes the
+# first-run password logic.
+ENTRYPOINT ["/usr/local/bin/elf-entrypoint.sh"]
+CMD ["/venv/bin/python", "-m", "maloja", "run"]

--- a/apps/maloja/elf-entrypoint.sh
+++ b/apps/maloja/elf-entrypoint.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+# Turn Maloja's MALOJA_FORCE_PASSWORD into a FIRST-RUN default.
+#
+# The problem this solves: upstream's force_password is not a seed, it is an
+# override, and setup() re-applies it on EVERY start (maloja/setup.py). Set it
+# in the chart and a tenant who changes their password in the web interface
+# finds it reverted at the next pod reschedule, which can be days later and
+# reads as an account being tampered with. Leave it unset instead and Maloja
+# generates a random 32-character password and prints it to stdout exactly
+# once, which is worse: on ElfHosted nobody sees the pod log, so the tenant is
+# locked out of admin mode with no way back.
+#
+# So: apply the initial password only when Maloja has never stored one, and get
+# out of the way afterwards.
+#
+# THE SENTINEL IS THE STORED USER, NOT THE EXISTENCE OF THE AUTH DATABASE.
+# That distinction is the whole correctness argument here, and getting it wrong
+# recreates the lockout this script exists to prevent:
+#
+#   doreah's AuthManager is constructed at IMPORT time of
+#   maloja.pkg_global.conf, and constructing it creates auth/auth.sqlite
+#   populated with doreah's factory user. That happens well before setup()
+#   reaches auth.change_pw(). So a first start that is killed in between (OOM,
+#   a node eviction, an unlucky rollout) leaves an auth.sqlite behind with no
+#   real password in it. A file-existence check would then say "not a first
+#   run" forever after, we would stop seeding, and Maloja would mint a random
+#   password nobody can read. Verified: importing conf alone creates the file,
+#   and still_has_factory_default_user() is still True afterwards.
+#
+# So ask doreah directly whether a real password has ever been stored. The
+# probe costs about a second of startup and imports exactly what Maloja is
+# about to import anyway.
+#
+# A tenant who sets MALOJA_FORCE_PASSWORD explicitly (through ElfBot) keeps
+# upstream's behaviour verbatim, including the reset-every-boot part. That is
+# the documented way back in after a forgotten password: set it, restart, sign
+# in, unset it.
+set -eu
+
+DATA_DIR="${MALOJA_DATA_DIRECTORY:-/config}"
+AUTH_DB="${DATA_DIR}/auth/auth.sqlite"
+
+# 0 = never stored a real password (seed it)
+# 1 = a real password is stored (leave it alone)
+# 2 = could not tell
+probe_needs_seeding() {
+    /venv/bin/python -c '
+import sys
+try:
+    from maloja.pkg_global.conf import auth
+except Exception as exc:
+    sys.stderr.write("probe: could not load maloja config: %r\n" % (exc,))
+    sys.exit(2)
+try:
+    sys.exit(0 if auth.still_has_factory_default_user() else 1)
+except Exception as exc:
+    sys.stderr.write("probe: could not read auth state: %r\n" % (exc,))
+    sys.exit(2)
+'
+}
+
+if [ -n "${MALOJA_FORCE_PASSWORD:-}" ]; then
+    echo "[elf-entrypoint] MALOJA_FORCE_PASSWORD is set explicitly; Maloja will reset the admin password to it on this and every start until it is unset."
+else
+    set +e
+    probe_needs_seeding
+    probe_rc=$?
+    set -e
+
+    case "${probe_rc}" in
+        0)
+            export MALOJA_FORCE_PASSWORD="${MALOJA_INITIAL_PASSWORD:-changemeelfie}"
+            echo "[elf-entrypoint] No admin password has ever been stored; seeding the initial one. Change it in Maloja and it will stick."
+            ;;
+        1)
+            echo "[elf-entrypoint] An admin password is already stored; leaving it alone."
+            ;;
+        *)
+            # The probe could not answer, so fall back to the coarse check. It
+            # is right in every case except the interrupted-first-start one
+            # described above, and that case cannot be detected without the
+            # probe that just failed. Seeding is the safer side of the coin: a
+            # tenant whose password is reset to the documented default can
+            # still get in and can still change it, whereas one whose password
+            # was randomly generated and printed to an unread log cannot.
+            if [ -f "${AUTH_DB}" ]; then
+                echo "[elf-entrypoint] WARNING: could not read Maloja's auth state; ${AUTH_DB} exists, so assuming a password is already stored and leaving it alone."
+            else
+                export MALOJA_FORCE_PASSWORD="${MALOJA_INITIAL_PASSWORD:-changemeelfie}"
+                echo "[elf-entrypoint] WARNING: could not read Maloja's auth state; no ${AUTH_DB} either, so treating this as a first start and seeding the initial password."
+            fi
+            ;;
+    esac
+fi
+
+# tini is invoked here rather than being the ENTRYPOINT, so that an overridden
+# command (CI's goss tests run `tail -f /dev/null`) still runs the logic above
+# and still gets a working init.
+exec /sbin/tini -- "$@"

--- a/apps/maloja/patches/0001-invalidate-id-caches-on-rollback.patch
+++ b/apps/maloja/patches/0001-invalidate-id-caches-on-rollback.patch
@@ -1,0 +1,37 @@
+diff --git a/maloja/database/sqldb.py b/maloja/database/sqldb.py
+index cb5e274..96d0df3 100644
+--- a/maloja/database/sqldb.py
++++ b/maloja/database/sqldb.py
+@@ -154,9 +154,29 @@ def connection_provider(func):
+ 			return func(*args,**kwargs)
+ 		else:
+ 			with engine.connect() as connection:
+-				with connection.begin():
+-					kwargs['dbconn'] = connection
+-					return func(*args,**kwargs)
++				try:
++					with connection.begin():
++						kwargs['dbconn'] = connection
++						return func(*args,**kwargs)
++				except Exception:
++					# The transaction has just rolled back, so every row it
++					# created is gone -- but the caches do not know that.
++					# get_track_id, get_artist_id and get_album_id are all
++					# @cached_wrapper, so an id that was allocated inside the
++					# failed transaction keeps being served to later calls.
++					#
++					# Writing a scrobble against such an id produces a row
++					# pointing at a track that does not exist, which makes
++					# count_scrobbles_by_track raise KeyError. Worse, SQLite
++					# hands that same rowid to the next entity created, so the
++					# orphaned scrobble is silently reattributed to an unrelated
++					# track.
++					#
++					# add_scrobble reaches this path on every rejected duplicate
++					# timestamp, which is routine for clients that retry.
++					invalidate_caches()
++					invalidate_entity_cache()
++					raise
+ 
+ 	wrapper.__innerfunc__ = func
+ 	wrapper.__name__ = f"CONPR_{func.__name__}"


### PR DESCRIPTION
Fixes a **silent data-corruption bug in Maloja 3.2.6** found while validating [EEP #180](https://github.com/elfhosted/enhancements/issues/180) on funkypenguin, and moves maloja's build into this repo because GPL-3.0 requires it.

## The bug

Reproducible in three requests, no timing games:

```
1) Alpha/SongA    ts=T      -> 200
2) Bravo/SongB    ts=T      -> 409 duplicate timestamp
3) Bravo/SongB    ts=T+100  -> 200, written against a track that does not exist
4) Charlie/SongC  ts=T+200  -> takes that rowid, absorbing the orphan
```

| | ts+0 | ts+100 | ts+200 |
| --- | --- | --- | --- |
| submitted | Alpha/SongA | **Bravo/SongB** | Charlie/SongC |
| 3.2.6 reports | Alpha/SongA | **Charlie/SongC** ← wrong | Charlie/SongC |
| patched | Alpha/SongA | **Bravo/SongB** ✓ | Charlie/SongC |

Found on a live tenant first, then reduced to the above.

## Cause

`get_track_id`, `get_artist_id` and `get_album_id` are all `@cached_wrapper`, and `add_scrobble` raises `DuplicateTimestamp` **inside** `connection_provider`'s `with connection.begin():`. The rollback discards the track row `scrobble_dict_to_db` just created, but the cache keeps its id and serves it to the next call. SQLite then reuses that rowid for the next entity created, so the orphaned scrobble is silently reattributed.

A duplicate-timestamp rejection is routine for scrobble clients that retry, and the ListenBrainz dialect is the one Navidrome uses, so tenants would hit this.

## The fix

In `connection_provider`, not in `add_scrobble`, because the invariant is general: **a cache must not outlive the rollback that erased what it points at.** Any future caller that raises out of an owned transaction gets the same protection. Full invalidation is deliberate (a rolled-back transaction may have populated any cached read with uncommitted state) and this path is only reached on failures, which are rare.

## One correction to an earlier claim

I originally reported this as "the charts endpoint 500s". That symptom is real (`count_scrobbles_by_track` raising `KeyError`) but **intermittent** — it needs the dangling id to fall inside the queried range with no cached result covering it. The misattribution is the reliable harm and the reason this matters.

## Why the build moves out of containers-private

**The rule: app builds live in containers-private. This repo carries a Dockerfile or a patch series only where the licence or collaborative work requires it.**

Maloja meets that test on its own merits: GPL-3.0 **and** patched. Shipping a modified GPL work means offering the Corresponding Source, so the patch and the recipe that applies it have to be public. Upstream at `v${VERSION}` + `./patches/` + this Dockerfile is the complete recipe; a patched binary built from a Dockerfile nobody outside ElfHosted can read would not satisfy it.

`ci/goss.yaml` stays private, matching the usual `ci/latest.sh`-public split — it is test configuration, not Corresponding Source.

> An earlier revision of this description also argued "132 apps already have a public Dockerfile here". That was a bad argument and `ebbc8c64` removes it from the file comment: those are historical drift, not permission. Maloja would qualify even if it were the only public build in the repo. **Please do not cite this PR as precedent for making an unrelated build public.**

`git apply`, not `patch(1)`, so a context mismatch fails the build loudly rather than fuzzing a hunk into the wrong place. Applied in the **builder** stage so the installed package carries it; patching `/source` after pip has copied the tree would be a no-op. Verified by grepping the fix out of `/venv/lib/python3.12/site-packages/`, not just trusting the build log.

## Verification

On `linux/amd64`, against the **CI-merged context** (this repo + containers-private overlaid, exactly as `action-image-build.yaml` assembles it):

- patch applies cleanly (`Applied patch maloja/database/sqldb.py cleanly.`)
- `goss` **23/23**
- the four-request sequence attributes every scrobble correctly

## Merge order and follow-up

Land this **before** containers-private#254, which deletes the now-duplicate private copies. The other order breaks the build, since the private copy currently shadows this one.

After merge: `Release: Manual` for `maloja` to rebuild. Note myprecious pins `tag: 3.2.6` with no digest, so a rebuilt same-tag image will not be re-pulled on nodes that already cached it — worth pinning the new digest in the chart once it exists.

Intended for upstream as well; see krateng/maloja.

🤖 Generated with [Claude Code](https://claude.com/claude-code)