### PR TITLE
feat(volsync): add mover image with GOMAXPROCS baked in

### DIFF
--- a/apps/volsync/Dockerfile
+++ b/apps/volsync/Dockerfile
@@ -1,0 +1,21 @@
+# ElfHosted volsync mover image.
+#
+# Identical to upstream except for one environment variable. restic is a Go
+# binary, and Go sizes its thread pool from the NODE's core count rather than
+# the container's CFS quota — 12 cores on surf through 88 on cc. Against the
+# mover's 2-core limit that is up to 44x oversubscription: the pool burns the
+# whole quota in the first milliseconds of each scheduling period and then
+# stalls for the remainder, so movers were observed pinned at their ceiling
+# while making poor progress.
+#
+# volsync exposes no mover env hook in ANY current release (checked 0.13.1
+# through v0.16.0: moverAffinity/PodLabels/Resources/SecurityContext/
+# ServiceAccount/Volumes only), so GOMAXPROCS cannot be set from the
+# ReplicationSource spec. Baking it into the image is the only route.
+#
+# GOMAXPROCS MUST match `limits.cpu` on moverResources in the myprecious
+# ReplicationSource templates. Change them together.
+ARG VERSION
+FROM quay.io/backube/volsync:${VERSION}
+
+ENV GOMAXPROCS=2

--- a/apps/volsync/ci/latest.sh
+++ b/apps/volsync/ci/latest.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# PINNED, not floating. The mover image and the volsync controller are
+# version-coupled: the controller invokes mover scripts that live in this image,
+# and their contract changes between minor releases. This must therefore track
+# the volsync chart deployed in infra (volsync-system/helmrelease-volsync.yaml),
+# NOT upstream's newest tag.
+#
+# To upgrade: bump the volsync HelmRelease and this pin in the same change.
+printf "%s" "0.13.1"

--- a/apps/volsync/metadata.json
+++ b/apps/volsync/metadata.json
@@ -1,0 +1,16 @@
+{
+  "app": "volsync",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Why

`restic` is a Go binary, and Go sizes its thread pool from the **node's** core count, not the container's CFS quota:

| DC | worker cores |
|---|---|
| surf / wine / cafe | 12–16 |
| party / coffee | 40 |
| .com | 12–64 |
| **cc** | **88** |

Against a 2-core mover limit that is up to **44× oversubscription** — the pool burns the entire quota in the first milliseconds of each scheduling period, then stalls for the remainder. Measured live on .com:

```
aa-assone/volsync-src-rs-config-lw7f4:  cpu=500m  mem=707Mi   <-- pinned at exactly the old limit
aa-limpyyy/volsync-src-rs-config-q6tbj: cpu=423m  mem=1409Mi
```

Throttling also stretches each sync, which lengthens the window a mover holds its peak memory — feeding the ~46 OOMKilled movers currently seen fleet-wide (cafe 23, cc 8, wine 7, coffee 7, .com 1).

**GOMAXPROCS is the right lever and cannot be reached from the chart.** volsync exposes no mover env hook in any current release — I checked the ReplicationSource CRD at 0.13.1, v0.14.0, v0.15.0 and v0.16.0: `moverAffinity`, `moverPodLabels`, `moverResources`, `moverSecurityContext`, `moverServiceAccount`, `moverVolumes` only. Upgrading volsync would not help. Baking it into the mover image is the only route, and the volsync helm chart happens to expose a dedicated restic mover image override (`restic.repository` / `restic.image` / `restic.tag`).

## What

A thin wrapper — upstream image, one environment variable:

```dockerfile
ARG VERSION
FROM quay.io/backube/volsync:${VERSION}
ENV GOMAXPROCS=2
```

`GOMAXPROCS=2` matches `limits.cpu: 2` in the myprecious ReplicationSource templates (elfhosted/myprecious#11325) — **the two must be changed together**, noted in the Dockerfile.

Only the *mover* image is overridden downstream; the volsync controller keeps the upstream image, so this changes nothing about the operator itself.

## Why `latest.sh` is pinned rather than floating

The mover image and the controller are **version-coupled** — the controller invokes mover scripts that live in this image, and their contract changes across minor releases. So `latest.sh` returns the version deployed in infra (`0.13.1`, confirmed against the live release's appVersion) rather than upstream's newest tag. Upgrading volsync means bumping the HelmRelease and this pin in the same change.

One wrinkle worth knowing: the infra HelmRelease tracks chart `0.13.x`, so the controller can float to a new patch while this stays at `0.13.1`. Patch-level skew should be harmless, but if 0.13.x moves it is worth re-pinning.

## ⚠️ Rollout ordering

Builds here trigger on `latest.sh` change or manual dispatch, **not** on file push — so **this image must exist in ghcr before the infra change lands**. If the volsync HelmRelease is pointed at `ghcr.io/elfhosted/volsync:0.13.1` before it is built, every restic mover fails ImagePullBackOff and **all backups stop fleet-wide**.

Order: merge this → trigger/await the build → confirm `ghcr.io/elfhosted/volsync:0.13.1` pulls → then merge the infra HelmRelease change.

## Verify after rollout

```sh
kubectl -n <tenant-ns> get pod <mover-pod> -o jsonpath='{.spec.containers[0].image}{"\n"}'
kubectl top pod -n <tenant-ns> <mover-pod>   # expect closer to 2 cores, and sustained rather than sawtoothing at the ceiling
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)