### PR TITLE
docs(ci): record why image builds stay on GitHub-hosted runners

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -1,6 +1,29 @@
 ---
 name: "Release: Manual"
 
+# Runner choice: these jobs stay on ubuntu-latest, deliberately.
+#
+# After the 2026-08-23 org billing failure, release-blocking workflows across
+# elfhosted were moved to the in-cluster arc-runners pool. The image builds here
+# are release-blocking by definition, so they were the obvious candidate -- and
+# were still ruled out, for three reasons:
+#
+#  1. This repo is PUBLIC, so its GitHub-hosted minutes are free and unmetered,
+#     and the spending-limit failure never touched them. Verified against the
+#     incident itself: while every ubuntu-latest job in the org's PRIVATE repos
+#     died in 4-5s for ~15h from 13:11Z, this repo's builds ran clean throughout
+#     (Release: Manual 21:03Z, 01:44Z; Image: Rebuild 01:55Z; hourly Renovate).
+#  2. arc could not run them anyway. The scale set declares no containerMode, so
+#     its runner pods have no Docker daemon (buildx cannot run) and no sudo/apt
+#     (the matrix job below installs moreutils + jo).
+#  3. It would trade resilience away, not gain it: ten 1-CPU runners with no
+#     layer cache instead of GitHub's free cached fleet, and the image-build path
+#     would then depend on the very cluster the images are deployed to.
+#
+# Revisit if this repo goes private, or if public-repo minutes start being
+# metered. See docs/DECISION-arc-runners-release-workflows.md in
+# elfhosted/shadowfax.
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Comment-only. Closes the "decide on the containers build workflows" item from `docs/BRIEF-arc-runners-release-workflows.md` (elfhosted/shadowfax#561), which called this the heavyweight case and asked for a deliberate decision rather than a silent deferral.

**The decision is: don't move them** — and the reason is not the one the brief expected.

1. **This repo is public, so it was never exposed.** GitHub-hosted minutes for public repos are free and unmetered, and the org spending-limit failure did not touch them. That held empirically through the incident: while every `ubuntu-latest` job in the org's *private* repos died in 4–5s for ~15h from 13:11Z, this repo's jobs ran clean — Release: Manual at 21:03Z and 01:44Z, Image: Rebuild at 01:55Z, and hourly Renovate throughout.
2. **arc couldn't run them anyway.** The scale set declares no `containerMode`, so runner pods have no Docker daemon (buildx is a non-starter) and no sudo/apt (`generate-build-matrix` installs `moreutils` and `jo`).
3. **It would cost resilience.** Ten 1-CPU runners with no layer cache, replacing GitHub's free cached fleet — and the image-build path would then depend on the same cluster the images get deployed to.

The comment goes in `release-manual.yaml` because that's where the next person will ask the question, and because the obvious-looking fix (a blanket `runs-on` swap) would break every build.

Revisit if this repo ever goes private, or if public-repo minutes start being metered.

Also spotted while looking, **not** addressed here: **`Release: Schedule` has been failing continuously** — before, during and after the incident. Those runs last 300–750s and then fail, so that's real job logic failing, not a 4-second billing rejection. Wanted to flag it rather than fold it into a docs PR.

Full inventory and rationale: `docs/DECISION-arc-runners-release-workflows.md` in elfhosted/shadowfax.