### PR TITLE
chore(parent): bump to 1.15.0 for screen-time limits

### DIFF
--- a/apps/parent/ci/latest.sh
+++ b/apps/parent/ci/latest.sh
@@ -6,4 +6,4 @@
 # stays put across rebuilds and imagePullPolicy: IfNotPresent leaves nodes that
 # already cached it running the OLD build forever. The chart pins the digest for
 # exactly that reason, but a moving tag is still the clearer signal.
-printf "%s" "1.14.0"
+printf "%s" "1.15.0"


### PR DESCRIPTION
apps/parent gained per-player daily screen-time limits (elfhosted/containers-private#260, merged). Version is hand-declared (no upstream), so this bump moves the tag and forces nodes off the cached 1.14.0 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
