### PR TITLE
chore(parent): bump to 1.16.0 for approved-players

### DIFF
--- a/apps/parent/ci/latest.sh
+++ b/apps/parent/ci/latest.sh
@@ -6,4 +6,4 @@
 # stays put across rebuilds and imagePullPolicy: IfNotPresent leaves nodes that
 # already cached it running the OLD build forever. The chart pins the digest for
 # exactly that reason, but a moving tag is still the clearer signal.
-printf "%s" "1.15.0"
+printf "%s" "1.16.0"


### PR DESCRIPTION
apps/parent gained the opt-in "only approved players may join" access control (elfhosted/containers-private#263, merged). Hand-declared version bump to move the tag off 1.15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
