### PR TITLE
feat(elfbassador): add app (metadata + version discovery)

### DIFF
--- a/apps/elfbassador/ci/latest.sh
+++ b/apps/elfbassador/ci/latest.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# elfbassador tags releases as vX.Y.Z, but its images have always been tagged
+# WITHOUT the v (ghcr.io/elfhosted/elfbassador:1.5.1, which is what
+# infra/elfbassador/helmrelease-elfbassador.yaml pins). Strip it here so the
+# series continues unbroken — switching to v-prefixed tags mid-stream risks
+# renovate not offering the bump at all, which fails silently.
+# The Dockerfile puts the v back to clone the tag.
+version=$(curl -sX GET https://api.github.com/repos/elfhosted/elfbassador/releases/latest --header "Authorization: Bearer ${ZURG_GH_CREDS}" | jq --raw-output '. | .tag_name')
+printf "%s" "${version#v}"

--- a/apps/elfbassador/metadata.json
+++ b/apps/elfbassador/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "elfbassador",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Public half of onboarding elfbassador — the last app still building its own image in its own repo. Pairs with [containers-private#268](https://github.com/elfhosted/containers-private/pull/268), which carries the Dockerfile; **both must land before a build resolves**.

Its `release-please.yml` `build-release-image` job pushes `ghcr.io/elfhosted/elfbassador`, which is what `infra/elfbassador/helmrelease-elfbassador.yaml` deploys.

## The one non-obvious bit

`ci/latest.sh` **strips the leading `v`** from the release tag. The repo tags `vX.Y.Z`, but its images have always been tagged without it — infra pins `1.5.1` — and switching to v-prefixed tags mid-stream risks renovate not offering the bump at all, which fails silently. The Dockerfile in containers-private puts the `v` back to clone the tag.

Tests disabled like gandalf's: the app's `/health` 503s until the bot connects to Discord, which needs a token CI doesn't have.

Verified by building the pair locally against `v1.5.1` — uid 568, entrypoint, `:8080` and deps all correct. After merge I'll dispatch `Release: Manual` and confirm the image lands before the in-repo build job is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
