### PR TITLE
fix(ci): repair version discovery for csi-rclone and jackettio

### DIFF
--- a/apps/csi-rclone/ci/latest.sh
+++ b/apps/csi-rclone/ci/latest.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
-# version=$(curl -sX GET "https://repology.org/api/v1/projects/?search=rclone&inrepo=alpine_edge" -A "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/81.0" | jq -r '.rclone | .[] | select((.repo == "alpine_edge" and .binname == "rclone")) | .version')
-# version="${version%%_*}"
-# version="${version%%-*}"
+# The tag is not decorative: the Dockerfile installs exactly this rclone
+# version (RCLONE_VERSION defaults to VERSION), so the tag states what is
+# in the image.
+#
+# This used to return a hardcoded v1.74.4 — the repology lookup was commented
+# out when it started 403ing, leaving only the "just fake it" fallback. That
+# pinned the app twice: the version never changed, so fetch.sh never saw a new
+# one and csi-rclone was never rebuilt on schedule again (its source repointed
+# to the private org repo on 2026-08-19 and no image was ever built from it),
+# and the bundled rclone never moved either.
+#
+# rclone's own releases API replaces repology — same answer, no scraping, and
+# it is the authority for what the download URL will accept.
+version=$(curl -L -sfX GET "https://api.github.com/repos/rclone/rclone/releases/latest" --header "Authorization: Bearer ${ZURG_GH_CREDS}" | jq --raw-output '.tag_name // empty')
 
-# If we get no result from upstream, just fake it
-if [[ "${version}" == "" ]]; then
-    version=1.74.4
-fi
-printf "%s" "v${version}"
-# printf "%s" "1.66.0" # the above link 403s currently
+# Print nothing on failure — fetch.sh reads empty as "lookup failed, skipping",
+# which is the correct outcome for a transient API error. Substituting a
+# constant is what silently froze this app for months.
+printf "%s" "${version}"

--- a/apps/jackettio/ci/latest.sh
+++ b/apps/jackettio/ci/latest.sh
@@ -1,3 +1,12 @@
 #!/usr/bin/env bash
-version=$(curl -L -sX GET "https://api.github.com/repos/elfhosted/jackettio-internal/commits/main" --header "Authorization: Bearer ${ZURG_GH_CREDS}" | jq --raw-output '.sha')
+# jackettio-internal's default branch is master, not main. This asked for
+# /commits/main, which 422s ("No commit found for SHA: main"), so the version
+# resolved to null and fetch.sh skipped the app every cycle — jackettio could
+# not be rebuilt at all. The published image is still tagged literally "null"
+# from 2026-05-22, minted before the build gained its null-tag guard.
+#
+# -f plus `// empty` so a failed lookup prints nothing rather than the string
+# "null": fetch.sh treats empty as "lookup failed, skipping", which is what
+# should have happened here all along.
+version=$(curl -L -sfX GET "https://api.github.com/repos/elfhosted/jackettio-internal/commits/master" --header "Authorization: Bearer ${ZURG_GH_CREDS}" | jq --raw-output '.sha // empty')
 printf "%s" "${version}"


### PR DESCRIPTION
Two apps had silently stopped being buildable on schedule. `fetch.sh` only queues a build when `published_version != upstream_version`, so a lookup that never changes — or never resolves — means the app is never rebuilt and **nothing says so**.

## csi-rclone: frozen on a constant

The repology lookup was commented out when it started 403ing, leaving only the `# If we get no result from upstream, just fake it` fallback. So `latest.sh` always returned `v1.74.4`, always equal to the published version, never a build.

The consequence is live: containers-private#235 repointed the build from the old public `funkypenguin` fork to `elfhosted/csi-rclone-reloaded` on **2026-08-19 11:05Z**, and nothing picked it up. The published `v1.74.4` dates from **2026-08-18 23:09Z** — before that. Production is running the old fork's code, without any of the eight `elf-mount-hardening` commits (staged mounts, maintenance sweeper, persistent VFS cache, `/metrics`).

Now reads rclone's own releases API — same answer repology was scraped for, no 403, and it's the authority for what the download URL will accept. Currently `v1.75.0`.

## jackettio: querying a branch that doesn't exist

`latest.sh` asked for `/commits/main` on a repo whose default branch is `master`. That 422s (`No commit found for SHA: main`), the version resolved to the string `"null"`, and the app was skipped every cycle. Its published image is still tagged literally **`null`**, minted before the build gained its null-tag guard.

## The shared fix

Both now print **nothing** when the lookup fails, so `fetch.sh` reads it as "lookup failed, skipping" rather than acting on a fabricated or `"null"` version. Substituting a constant for a failed lookup is precisely what hid both of these for months.

csi-rclone pairs with [containers-private#269](https://github.com/elfhosted/containers-private/pull/269), which makes the Dockerfile's `RCLONE_VERSION` default to `VERSION` so the tag and the bundled binary can't drift apart again.

## Tested against the live APIs

```
csi-rclone  -> v1.75.0
jackettio   -> e33c24fbc4a2a1785797d580f78cd44120266039
both, bad token -> (empty)
```

Neither auto-rolls to prod: infra pins csi-rclone by hand in plain manifests, and jackettio by `rolling@sha256`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)