### PR TITLE
feat(postiz): enable goss tests with a temporal/glibc regression guard

### DIFF
--- a/apps/postiz/ci/goss.yaml
+++ b/apps/postiz/ci/goss.yaml
@@ -1,18 +1,36 @@
 ---
-# https://github.com/aelsabbahy/goss/blob/master/docs/manual.md#process
-# process:
-#   python3:
-#     running: true
-#   ttyd:
-#     running: true    
+# Postiz runs three pm2 children: frontend (4200), backend (3000) and
+# orchestrator (3002). dgoss starts the container with NO Postgres and NO Redis,
+# so the backend and orchestrator cannot reach a listening state here even on a
+# good image -- the port check below therefore covers the frontend only, and the
+# real correctness guard is the command check.
 
-# https://github.com/aelsabbahy/goss/blob/master/docs/manual.md#port
+command:
+  # REGRESSION GUARD -- do not delete without reading this.
+  #
+  # @temporalio/core-bridge (via @temporalio/worker) is a prebuilt Rust addon
+  # published ONLY for x86_64-unknown-linux-gnu. Built on a musl base (alpine)
+  # it cannot dlopen ld-linux-x86-64.so.2, and that takes down BOTH the backend
+  # and the orchestrator:
+  #
+  #   Error: Error loading shared library ld-linux-x86-64.so.2: No such file or
+  #   directory (needed by .../core-bridge/releases/
+  #   x86_64-unknown-linux-gnu/index.node)
+  #
+  # This is invisible to a port or HTTP check: pm2 restarts the dead children
+  # forever, so the container stays Running and 1/1 Ready while nginx and the
+  # frontend serve 500s. It shipped undetected for months because tests were
+  # disabled for this app.
+  #
+  # require() reproduces it directly and needs no external services. If this
+  # starts failing, the base image has drifted back to musl -- see the Dockerfile.
+  temporalio-core-bridge-loads:
+    exec: node -e "require('/app/node_modules/@temporalio/core-bridge')"
+    exit-status: 0
+    timeout: 60000
+
 port:
-  # https://github.com/aelsabbahy/goss/issues/149
-  tcp:5000:
+  # tcp6, NOT tcp -- the Next.js frontend binds v6 only. `tcp:4200` reports
+  # not-listening against a perfectly healthy container.
+  tcp6:4200:
     listening: true
-
-# https://github.com/aelsabbahy/goss/blob/master/docs/manual.md#http
-http:
-  http://localhost:5000:
-    status: 200

--- a/apps/postiz/metadata.json
+++ b/apps/postiz/metadata.json
@@ -9,9 +9,9 @@
       ],
       "stable": true,
       "tests": {
-        "enabled": false,
+        "enabled": true,
         "type": "web"
       }
-    }   
+    }
   ]
 }


### PR DESCRIPTION
Enables the goss suite for postiz and replaces the stale template with checks that would actually have caught the musl/glibc breakage fixed in containers-private#272.

## Why this was needed

`tests.enabled` was `false`, and `ci/goss.yaml` was an untouched template probing **port 5000** — a port postiz has never listened on. Nothing exercised the image. That is how a base image that could not start the backend *at all* shipped undetected for months.

## The checks

**`command/temporalio-core-bridge-loads`** — the real guard. `node -e "require(.../core-bridge)"`. Validated against the live broken pod: exits **1** with the exact dlopen error on the musl image, and will exit 0 once the base is glibc.

This matters because the failure is invisible to port and HTTP checks: pm2 restarts the dead backend and orchestrator forever, so the container stays `Running` / `1/1 Ready` while the frontend serves 500s. A conventional web check passes on a completely broken image.

**`port/tcp6:4200`** — the frontend. Confirmed listening on the live pod. Note **tcp6, not tcp**: Next.js binds v6 only, and `tcp:4200` false-fails a healthy container.

## Deliberate omissions

No assertions on 3000/3002 and no HTTP check. dgoss runs the container with no Postgres and no Redis, so the backend and orchestrator cannot reach a listening state even on a good image — asserting them would fail every build. The command guard covers the correctness question without needing those services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)