### PR TITLE
fix(ci): free runner disk before Trivy, so large images can be pushed

### DIFF
--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -339,6 +339,34 @@ jobs:
           # Exit with dgoss status so the job still fails on test failures.
           exit $STATUS
 
+      # Trivy extracts every layer UNCOMPRESSED to scan it, so peak disk is far
+      # larger than the image. whisperx (CUDA runtime + torch CUDA libs + 3GB of
+      # baked model weights) exhausted the runner and died after 14 minutes with
+      # "write /tmp/fanal-...: no space left on device". The scan then produced
+      # no SARIF, the upload step failed, and — because later steps are gated on
+      # it — "Build all platforms" was SKIPPED, so a perfectly good image that
+      # had already passed goss was never pushed.
+      #
+      # Reclaimed inline rather than via a third-party free-disk action: this
+      # runs on every image in the repo, and an unpinned action at @main is a
+      # supply-chain surface we would rather not add to a build that pushes to
+      # ghcr. These paths are GitHub-managed toolchains no build here uses.
+      #
+      # Runs before the scan rather than before the build, so ordinary builds
+      # pay nothing extra beyond the one rm.
+      - name: Free runner disk before scanning
+        shell: bash
+        run: |
+          echo "before:"; df -h / | tail -1
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/share/boost \
+            /usr/share/swift \
+            /opt/hostedtoolcache/CodeQL 2>/dev/null || true
+          echo "after:"; df -h / | tail -1
+
       - name: Scan container image for CVEs
         id: trivy_scan
         continue-on-error: true


### PR DESCRIPTION
Trivy extracts every layer **uncompressed** to scan it, so peak disk far exceeds the image size. whisperx (CUDA runtime + torch CUDA libs + 3GB of baked model weights) exhausted the runner and died after 14 minutes:

```
FATAL image scan error: ... write /tmp/fanal-722331355: no space left on device
```

**The consequence is worse than a failed scan.** With no SARIF produced, the upload step failed, and because later steps are gated on it, **"Build all platforms" was skipped** — so an image that had already passed goss (including the new real-transcription check, `Count: 12, Failed: 0`) was never pushed. An earlier build of the same image happened to fit, so this looks like flakiness rather than a limit being reached.

Reclaims ~25GB of GitHub-managed toolchains no build here uses (Android SDK, .NET, GHC, boost, Swift, CodeQL cache).

**Inline rather than a third-party action** — this runs for every image in the repo, and an unpinned action at `@main` is a supply-chain surface I'd rather not add to a job that pushes to ghcr.

**Placed before the scan, not before the build**, so ordinary builds pay nothing beyond the one `rm`.

**Deliberately not changed:** the upload step still fails the build when it can't produce a SARIF. That's fail-closed on the security gate and worth keeping now the common cause is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)