### PR TITLE
feat(pinepods-ai): image metadata for the Pinepods transcription adapter

### DIFF
--- a/apps/pinepods-ai/ci/latest.sh
+++ b/apps/pinepods-ai/ci/latest.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# `pinepods-ai` is our own code — an adapter between Pinepods' AI sidecar
+# protocol and the shared whisperx service — so there is no upstream release to
+# track and renovate has nothing to watch. The version is declared here and
+# bumped by hand.
+#
+# Bump this when apps/pinepods-ai/ changes in containers-private. Without a bump
+# the tag stays put across rebuilds, and imagePullPolicy: IfNotPresent leaves
+# nodes that already cached it running the OLD build forever. The chart pins the
+# digest for exactly that reason, but a moving tag is still the clearer signal.
+printf "%s" "1.0.0"

--- a/apps/pinepods-ai/metadata.json
+++ b/apps/pinepods-ai/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "pinepods-ai",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Public half of a new in-house image. Dockerfile, source and goss suite are in elfhosted/containers-private#277.

`pinepods-ai` adapts Pinepods' AI-sidecar protocol onto the shared whisperx service. Pinepods POSTs `/transcribe` a **local** `file_path`, assuming the sidecar shares its downloads mount — and with no RWX in the fleet, the GPU pool on `.coffee` cannot read a tenant's disk in another cluster. So the adapter runs inside the tenant's Pinepods pod and uploads the bytes.

Our own code, so `latest.sh` declares the version by hand: there is no upstream release to track and renovate has nothing to watch. Bump it whenever `apps/pinepods-ai/` changes in containers-private, or `IfNotPresent` leaves cached nodes on the old build.

Tests enabled — the private goss suite drives a real second instance of the adapter against a stub whisperx and validates the result line against Pinepods' Rust structs.

**Needs a manual Release run after merge**: a push to this repo only runs CodeQL, so a new app's image is never built by the merge itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)