### PR TITLE
ci(release-schedule): trigger from the cluster, not GitHub's cron

### DIFF
--- a/.github/workflows/release-schedule.yaml
+++ b/.github/workflows/release-schedule.yaml
@@ -2,10 +2,26 @@
 name: "Release: Schedule"
 
 on:
+  # Triggered externally via workflow_dispatch by a k8s CronJob (see infra:
+  # cronjobs/dispatch-containers-release--flux-system) hourly at :30 UTC.
+  #
+  # There is deliberately no `schedule:` block here. GitHub deprioritises
+  # scheduled workflows and silently drops ticks: over one 17-hour sample this
+  # workflow's own "30 * * * *" cron fired 12 times instead of 17, with gaps up
+  # to 2h18m. Every dropped tick delays every app whose upstream cut a release
+  # in that window, and the delay is invisible — nothing fails, the build just
+  # does not happen.
   workflow_dispatch:
-  schedule:
-    # Run on the half-hour
-    - cron: "30 * * * *"
+
+# A full matrix build routinely outlives the hourly dispatch interval. Because
+# fetch.sh compares against PUBLISHED tags, an overlapping run re-derives the
+# same not-yet-pushed changes and both runs race to push the same tag at
+# different digests — churning renovate PRs and tenant clusters. Queue instead:
+# cancel-in-progress: false lets the running build finish, and GitHub keeps at
+# most one pending run, whose matrix is generated fresh when it starts.
+concurrency:
+  group: release-schedule
+  cancel-in-progress: false
 
 env:
   TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
> **Draft on purpose — do not merge until elfhosted/infra#20140 is merged and a cluster dispatch has been observed to land.** This PR removes the only automatic trigger this workflow currently has.

## Why

GitHub deprioritises scheduled workflows and silently drops ticks. Over one 17-hour sample this workflow's `"30 * * * *"` cron fired **12 times instead of 17**, with gaps up to **2h18m**:

```
13:45 14:43 15:58 16:44 18:04 19:12 20:04 21:17 22:26 23:37 — 02:04 — 04:14
```

`harbor-themes-v0.11.5` was tagged upstream at 05:19 UTC on 2026-08-27; the matrix had last run at 04:14. The image sat unbuilt for over two hours with nothing reporting a failure — `fetch.sh` had correctly seen no change on its last run, and the next run never came.

Replaced by a k8s CronJob in infra (`cronjobs/dispatch-containers-release--flux-system`) firing `workflow_dispatch` hourly at :30, the same cadence this file used to declare. Same pattern `elfhosted/myprecious`' release-please workflow already uses.

## Also: workflow-level concurrency

A full matrix build routinely outlives the dispatch interval. Because `fetch.sh` compares against **published** tags, an overlapping run re-derives the same not-yet-pushed changes, and both runs race to push the same tag at different digests — churning renovate PRs and tenant clusters.

That was previously masked by the dropped ticks. With a reliable hourly trigger it would not be. `cancel-in-progress: false` lets a running build finish; GitHub keeps at most one pending run, whose matrix is generated fresh when it starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)