### PR TITLE
feat(zurg): build from zurg-public v1.0.0 instead of the nightly stream

### DIFF
--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -295,6 +295,14 @@ jobs:
               -e STORAGE_TYPE=filesystem
               -e ENCRYPTION_KEY="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
             )
+          elif [[ "${{ matrix.image.app }}" == "zurg" ]]; then
+            # zurg-public ships no config.yml (the chart seeds one from a
+            # ConfigMap at runtime). Started bare, zurg writes a default config
+            # and then EXITS, telling you to add a token -- which would fail the
+            # process.zurg goss check. Given a token it writes the same default
+            # config and stays up retrying auth, so feed it a well-formed dummy.
+            # Real-Debrid still rejects it, which is what we want in CI.
+            DGOSS_RUN_ARGS+=(-e TOKEN="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
           fi
 
           cleanup() {

--- a/apps/zurg/Dockerfile
+++ b/apps/zurg/Dockerfile
@@ -1,14 +1,19 @@
 ARG VERSION
-FROM ghcr.io/debridmediamanager/zurg-testing:${VERSION} as upstream
+FROM ghcr.io/debridmediamanager/zurg-public:${VERSION} as upstream
 FROM ghcr.io/elfhosted/alpine:3.19.1@sha256:dfb0a18161228f317ed4c96630d70d7855d546a522c0017cbe76b907dabae8ec 
 
 WORKDIR /config
 
-# Needed for the plex-update script
-RUN apk add --no-cache python3 libxml2-utils 
+# Runtime deps, matched to zurg-rc so the two images are interchangeable:
+#   python3 + libxml2-utils  plex_update.sh / cli_debrid_update.sh
+#   ffmpeg (ffprobe)         media_info_* directory filters (audiobooks)
+#   curl                     WARP readiness wait in the entrypoint
+#   socat                    decypharr-replacement stub in the entrypoint
+RUN apk add --no-cache python3 libxml2-utils ffmpeg curl socat
 
+# zurg-public ships only the binary -- no config.yml. The chart seeds
+# /config/config.yml from the zurg-config ConfigMap, so nothing needs one here.
 COPY --from=upstream /app/zurg /app/
-COPY --from=upstream /app/config.yml /config/
 COPY ./apps/zurg/entrypoint.sh /entrypoint.sh
 
 CMD ["/entrypoint.sh"]

--- a/apps/zurg/ci/latest.sh
+++ b/apps/zurg/ci/latest.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-version=$(curl -L -sX GET https://api.github.com/repos/debridmediamanager/zurg-testing/releases/latest --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '. | .tag_name')
+version=$(curl -L -sX GET https://api.github.com/repos/debridmediamanager/zurg-public/releases/latest --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '. | .tag_name')
 version="${version#*release-}"
 printf "%s" "${version}"    
-

--- a/apps/zurg/entrypoint.sh
+++ b/apps/zurg/entrypoint.sh
@@ -18,10 +18,10 @@ fi
 
 if [[ "${DECYPHARR_REPLACE_ZURG:-"false"}" == "true" ]]; then
     echo "Zurg is replaced by decypharr, doing nothing.."
-    nc -l 9999
+    while true; do
+        socat TCP-LISTEN:9998,reuseaddr,fork SYSTEM:"printf 'HTTP/1.1 200 OK\r\nContent-Length: 44\r\n\r\nZurg is replaced by decypharr, doing nothing!'"
+    done
 else
     cd /config
-    exec \
-        /app/zurg --config /config/config.yml
+    exec /app/zurg --config /config/config.yml
 fi
-


### PR DESCRIPTION
Moves the tenant-facing zurg image off `ghcr.io/elfhosted/zurg-rc` (a nightly source build of the private `debridmediamanager/zurg` repo) onto the public prebuilt release line, `ghcr.io/debridmediamanager/zurg-public` at `v1.0.0`.

**Why:** renovate bumped the nightly tag every single day, and every bump restarted every Real-Debrid tenant stack.

**Tradeoff, stated up front:** `v1.0.0` is commit `f2f88e3a` from 2026-08-09; the nightly stream is at 2026-08-31. This rolls back ~3 weeks of upstream work, and the previous public release before `v1.0.0` was July 2024 — future fixes may be slow to arrive. That is the price of the restart cadence.

### Changes

- `FROM zurg-public` (the repo/package rename of `zurg-testing`) at `${VERSION}`
- Dropped the `config.yml` COPY — **zurg-public ships only the binary**, so keeping it would fail the build. The chart seeds `/config/config.yml` from the `zurg-config` ConfigMap and the PVC masks `/config` anyway, so nothing needs one in the image.
- Added `ffmpeg curl socat` to match the zurg-rc runtime set. **ffprobe is load-bearing** — the `audiobooks` directory filter uses `media_info_duration_gte`, and the old `zurg` image never installed it.
- Took the zurg-rc entrypoint verbatim so the two images are drop-in interchangeable.
- `ci/latest.sh` follows the repo rename.
- **dgoss harness:** started bare, `v1.0.0` writes a default config and then *exits* (`update it with your token, then rerun`), which fails the `process.zurg` assertion and would block the release build. Given a token in env it writes the same default and stays up retrying auth, so a dummy token is passed for the goss run. Real-Debrid rejects it, as intended.

### Verification

Built locally and run as uid 568 with `--read-only`, against a real post-`setup.sh` tenant `config.yml`: loads cleanly and behaves as the nightly does. Goss scenario (token only, no config) stays alive past 75s.

Reviewed by codex (`--base main`); the goss gap above was its finding, and the re-review after the fix was clean.

### Notes / follow-ups

- `ghcr.io/elfhosted/zurg` no longer exists (404 — swept in the 2026-08-25 GHCR cleanup), so this republishes as a **new** package and will land `internal`; needs the re-sealed pull secret.
- myprecious repin to `ghcr.io/elfhosted/zurg:v1.0.0@sha256:…` follows once this builds (dev first, then promote).
- Pre-existing, not touched: `apps/zurg/rc/` is dead (not in `metadata.json` channels) but still builds from the private source.