### PR TITLE
feat(mellon): build metadata for the Nuvio-compatible sync backend

### DIFF
--- a/apps/mellon/ci/latest.sh
+++ b/apps/mellon/ci/latest.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# elfhosted/mellon is private — auth via ZURG_GH_CREDS.
+#
+# Falls back to the main-branch sha when no release exists yet, because an empty
+# version would be passed to `git clone -b` and fail with a much less obvious
+# error than "there is no release".
+version=$(curl -L -sX GET https://api.github.com/repos/elfhosted/mellon/releases/latest --header "Authorization: Bearer ${ZURG_GH_CREDS}" | jq --raw-output '.tag_name // empty')
+if [[ -z "${version}" ]]; then
+    version=$(curl -L -sX GET https://api.github.com/repos/elfhosted/mellon/commits/main --header "Authorization: Bearer ${ZURG_GH_CREDS}" | jq --raw-output '.sha[0:7] // empty')
+fi
+printf "%s" "${version}"

--- a/apps/mellon/metadata.json
+++ b/apps/mellon/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "mellon",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds build metadata for `mellon`, ElfHosted's Nuvio-compatible sync backend (source: private repo `elfhosted/mellon`).

- Tests disabled: mellon needs a reachable Postgres to start, which standalone goss cannot provide. `ci/goss.yaml` in containers-private is there for ad-hoc dgoss runs against a container that already has a database.
- `latest.sh` falls back to the main-branch sha until the first release exists, because an empty version reaches `git clone -b` and fails less obviously than "there is no release".

Paired with elfhosted/containers-private#feat/mellon, which carries the Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)