### PR TITLE
fix(mealie): resolve latest release lookup

### DIFF
--- a/apps/mealie/ci/latest.sh
+++ b/apps/mealie/ci/latest.sh
@@ -1,3 +1,14 @@
 #!/usr/bin/env bash
-version=$(curl -L -sX GET "https://api.github.com/repos/mealie-recipes/mealie/releases/latest" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.tag_name')
-printf "%s" "${version}"
+set -euo pipefail
+
+headers=()
+if [[ -n "${TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN:-}}}" ]]; then
+  headers=(-H "Authorization: Bearer ${TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN}}}")
+fi
+
+version=$(curl -fsSL "${headers[@]}" "https://api.github.com/repos/mealie-recipes/mealie/releases/latest" | jq --raw-output .tag_name)
+if [[ -z "$version" || "$version" == "null" ]]; then
+  echo "failed to resolve latest Mealie release" >&2
+  exit 1
+fi
+printf "%s" "$version"


### PR DESCRIPTION
## Summary
- Fix Mealie latest.sh so it no longer sends a literal redacted bearer token.
- Use available TOKEN/GITHUB_TOKEN/GH_TOKEN when present, otherwise query public releases unauthenticated.
- Fail loudly if GitHub returns null/empty.

## Verification
- `apps/mealie/ci/latest.sh main` -> `v3.25.0`
- Full Mealie image build and runtime smoke passed with matching private branch.

Refs: Discord request 1545162724428750899