### PR TITLE
feat(replay): build definition for RePlay

### DIFF
--- a/apps/replay/Dockerfile
+++ b/apps/replay/Dockerfile
@@ -1,0 +1,46 @@
+# RePlay: a single static page that reads a viewer's own Stremio or Nuvio
+# record back to them. Source (AGPL-3.0) lives in elfhosted/replay; this
+# Dockerfile is published alongside it because the AGPL's corresponding
+# source includes the scripts used to build and run the service.
+#
+# There is no application server. The page talks to the viewer's backend
+# from their browser, so all this image does is serve three static files.
+
+FROM alpine:latest AS cloner
+
+ARG CHANNEL
+ARG VERSION
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache git
+
+RUN git clone -b $VERSION https://github.com/elfhosted/replay /source
+
+# ---
+
+FROM alpine:3.22
+
+ARG VERSION
+ARG user=elfie
+
+# httpd is not in Alpine's stock busybox; it ships in busybox-extras.
+RUN apk add --no-cache tini busybox-extras && \
+    addgroup -S ${user} -g 568 && adduser -S ${user} -G ${user} -u 568
+
+WORKDIR /app
+
+COPY --from=cloner /source/index.html /source/og.png /source/LICENSE /app/
+
+# Stamp the release into the page so the footer reports what is deployed.
+# Fail the build rather than ship a page claiming to be a dev build.
+RUN sed -i "s/__REPLAY_VERSION__/${VERSION}/" /app/index.html && \
+    ! grep -q "__REPLAY_VERSION__" /app/index.html && \
+    chown -R 568:568 /app
+
+USER 568
+
+EXPOSE 8080
+
+# -f keeps httpd in the foreground; tini reaps and forwards signals.
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["httpd", "-f", "-p", "8080", "-h", "/app"]

--- a/apps/replay/ci/goss.yaml
+++ b/apps/replay/ci/goss.yaml
@@ -1,0 +1,23 @@
+---
+# RePlay is a static page served by busybox httpd, so there is no application
+# process to assert on beyond the server itself.
+process:
+  httpd:
+    running: true
+
+port:
+  tcp:8080:
+    listening: true
+
+http:
+  http://localhost:8080/:
+    status: 200
+    body:
+      # the page rendered, and the build stamped a version into it
+      - "RePlay"
+      - "Your activity, and who can see it"
+    # a placeholder here means the version substitution silently failed
+    "!body":
+      - "__REPLAY_VERSION__"
+  http://localhost:8080/og.png:
+    status: 200

--- a/apps/replay/ci/latest.sh
+++ b/apps/replay/ci/latest.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# elfhosted/replay is a public repo, but ZURG_GH_CREDS is used consistently
+# across our own sources so the call is authenticated and not rate-limited.
+# `// empty` returns "" rather than "null" before the first release exists,
+# which CI handles gracefully.
+version=$(curl -L -sX GET https://api.github.com/repos/elfhosted/replay/releases/latest --header "Authorization: Bearer ${ZURG_GH_CREDS}" | jq --raw-output '.tag_name // empty')
+printf "%s" "${version}"

--- a/apps/replay/metadata.json
+++ b/apps/replay/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "replay",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Build definition for [RePlay](https://github.com/elfhosted/replay), which reads a viewer's own Stremio or Nuvio record back to them and shows who else can see it.

There is no application server. The browser talks to the viewer's backend directly, so the image is three static files served by `busybox httpd` as `elfie` on a read-only rootfs, about 15MB.

- `httpd` comes from **busybox-extras**; it is not in Alpine's stock busybox (the first build exited with `applet not found`)
- The release tag is substituted into the page at build time so the footer reports what is deployed, and the build **fails** rather than shipping a page still saying `__REPLAY_VERSION__`
- `goss` asserts the page renders, `og.png` serves, and no placeholder survives

Built and run locally: serves both files with correct content types, `uid=568(elfie)`, read-only rootfs confirmed, version stamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)