### PR TITLE
fix(replay): drop the goss port check

### DIFF
--- a/apps/replay/ci/goss.yaml
+++ b/apps/replay/ci/goss.yaml
@@ -5,10 +5,9 @@ process:
   httpd:
     running: true
 
-port:
-  tcp:8080:
-    listening: true
-
+# No `port` block on purpose. busybox binds 0.0.0.0:8080, which goss does not
+# match against a bare `tcp:8080` key (goss#149), and the HTTP checks below
+# already prove the port is both listening and serving.
 http:
   http://localhost:8080/:
     status: 200


### PR DESCRIPTION
Only `port: tcp:8080` failed; httpd, both HTTP endpoints and the version-substitution body assertion all passed. busybox binds `0.0.0.0:8080` which goss won't match against a bare `tcp:8080` key ([goss#149](https://github.com/goss-org/goss/issues/149)).

Dropped rather than guessed at: the HTTP checks already prove the port is listening and serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)