### PR TITLE
feat(replay): ship favicon.ico

### DIFF
--- a/apps/replay/Dockerfile
+++ b/apps/replay/Dockerfile
@@ -29,7 +29,7 @@ RUN apk add --no-cache tini busybox-extras && \
 
 WORKDIR /app
 
-COPY --from=cloner /source/index.html /source/og.png /source/LICENSE /app/
+COPY --from=cloner /source/index.html /source/og.png /source/favicon.ico /source/LICENSE /app/
 
 # Stamp the release into the page so the footer reports what is deployed.
 # Fail the build rather than ship a page claiming to be a dev build.

--- a/apps/replay/ci/goss.yaml
+++ b/apps/replay/ci/goss.yaml
@@ -20,3 +20,5 @@ http:
       - "var VERSION = 'v"
   http://localhost:8080/og.png:
     status: 200
+  http://localhost:8080/favicon.ico:
+    status: 200


### PR DESCRIPTION
RePlay declares an inline SVG favicon as of v0.1.2, but clients that ignore the `<link>` and fetch `/favicon.ico` directly were served whatever the CDN had cached for a path the origin 404s (in production, a red X). Ship the real icon and assert it in goss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)