### PR TITLE
fix(replay): serve favicon.ico with a Content-Type

### DIFF
--- a/apps/replay/Dockerfile
+++ b/apps/replay/Dockerfile
@@ -31,6 +31,11 @@ WORKDIR /app
 
 COPY --from=cloner /source/index.html /source/og.png /source/favicon.ico /source/LICENSE /app/
 
+# busybox httpd has no .ico in its MIME table and would otherwise serve the
+# favicon with no Content-Type at all. httpd.conf is read from the -h directory
+# and httpd refuses to serve it (403), so it adds no exposure.
+RUN printf '.ico:image/x-icon\n' > /app/httpd.conf
+
 # Stamp the release into the page so the footer reports what is deployed.
 # Fail the build rather than ship a page claiming to be a dev build.
 RUN sed -i "s/__REPLAY_VERSION__/${VERSION}/" /app/index.html && \

--- a/apps/replay/ci/goss.yaml
+++ b/apps/replay/ci/goss.yaml
@@ -22,3 +22,6 @@ http:
     status: 200
   http://localhost:8080/favicon.ico:
     status: 200
+    # busybox serves .ico with no Content-Type unless httpd.conf maps it.
+    headers:
+      - "Content-Type: image/x-icon"


### PR DESCRIPTION
busybox httpd has no `.ico` entry in its MIME table, so `/favicon.ico` was served with **no Content-Type header at all** (`.html` and `.png` are fine). Browsers sniff it; unfurlers and strict proxies need not.

Maps it via `httpd.conf`, which busybox reads from the `-h` directory and refuses to serve itself (verified: 403).

Validated with the real goss 0.4.10 binary against a live busybox container rather than assuming the schema: passes with the fix (6/6), and the negative control without `httpd.conf` fails exactly the new header check (1/6 failed).

Source is unchanged, so this needs no new release: it is a rebuild of v0.1.2 producing a new digest, which renovate picks up on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)