### PR TITLE
fix(nightscout): restore versioned builds and runtime tests

### DIFF
--- a/.github/workflows/action-image-build.yaml
+++ b/.github/workflows/action-image-build.yaml
@@ -239,6 +239,23 @@ jobs:
               -e MEDIAFUSION_AUTO_MIGRATE=true
               -e SECRET_KEY="mediafusion-goss-secret-key-32b"
             )
+          elif [[ "${{ matrix.image.app }}" == "nightscout" ]]; then
+            NET="${NAME}-net"
+            MONGO="${NAME}-mongo"
+            docker network create "$NET"
+            docker run -d --name "$MONGO" --network "$NET" mongo:4.4
+            for i in {1..60}; do
+              if docker exec "$MONGO" mongosh --quiet --eval 'db.runCommand({ ping: 1 }).ok' >/dev/null 2>&1; then
+                break
+              fi
+              sleep 1
+            done
+            DGOSS_RUN_ARGS+=(
+              --network "$NET"
+              -e MONGO_CONNECTION="mongodb://$MONGO:27017/nightscout"
+              -e API_SECRET="nightscout-goss-secret-123"
+              -e INSECURE_USE_HTTP=true
+            )
           elif [[ "${{ matrix.image.app }}" == "mediastorm" ]]; then
             NET="${NAME}-net"
             PG="${NAME}-postgres"
@@ -308,6 +325,9 @@ jobs:
           cleanup() {
             if [[ "${{ matrix.image.app }}" == "mediafusion" ]]; then
               docker rm -f "${NAME}-postgres" "${NAME}-redis" >/dev/null 2>&1 || true
+              docker network rm "${NAME}-net" >/dev/null 2>&1 || true
+            elif [[ "${{ matrix.image.app }}" == "nightscout" ]]; then
+              docker rm -f "${NAME}-mongo" >/dev/null 2>&1 || true
               docker network rm "${NAME}-net" >/dev/null 2>&1 || true
             elif [[ "${{ matrix.image.app }}" == "mediastorm" ]]; then
               docker rm -f "${NAME}-postgres" >/dev/null 2>&1 || true

--- a/apps/nightscout/Dockerfile
+++ b/apps/nightscout/Dockerfile
@@ -2,13 +2,11 @@
 FROM alpine:latest as cloner
 ARG VERSION
 
-RUN apk update && apk upgrade && \
-    apk add --no-cache git
+RUN apk add --no-cache git
 
-# for now, just clone latest
-RUN git clone https://github.com/nightscout/cgm-remote-monitor.git /source
+RUN git clone --depth 1 --branch "${VERSION}" https://github.com/nightscout/cgm-remote-monitor.git /source
 
-FROM node:16.16.0-alpine
+FROM node:22-alpine
 
 LABEL maintainer="Nightscout Contributors"
 

--- a/apps/nightscout/ci/goss.yaml
+++ b/apps/nightscout/ci/goss.yaml
@@ -1,16 +1,13 @@
 ---
-# https://github.com/aelsabbahy/goss/blob/master/docs/manual.md#process
 process:
   node:
     running: true
 
-# https://github.com/aelsabbahy/goss/blob/master/docs/manual.md#port
 port:
-  # https://github.com/aelsabbahy/goss/issues/149
   tcp:1337:
     listening: true
 
-# https://github.com/aelsabbahy/goss/blob/master/docs/manual.md#http
-# http:
-#   http://localhost:1337:
-#     status: 200
+http:
+  http://localhost:1337/api/v1/status.json:
+    status: 200
+    timeout: 5000

--- a/apps/nightscout/ci/latest.sh
+++ b/apps/nightscout/ci/latest.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
-version=$(curl -L -sX GET https://api.github.com/repos/nightscout/cgm-remote-monitor/releases/latest --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '. | .tag_name')
-printf "%s" "${version}"    
+set -euo pipefail
 
+auth_token="${TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN:-}}}"
+headers=(-H "Accept: application/vnd.github+json")
+if [[ -n "${auth_token}" ]]; then
+  headers+=(-H "Authorization: Bearer ${auth_token}")
+fi
+
+version=$(curl -fsSL "${headers[@]}"   https://api.github.com/repos/nightscout/cgm-remote-monitor/releases/latest   | jq --raw-output '.tag_name // empty')
+
+if [[ -z "${version}" || "${version}" == "null" ]]; then
+  echo "nightscout latest release resolved empty/null" >&2
+  exit 1
+fi
+
+printf "%s" "${version}"


### PR DESCRIPTION
## Summary
- fix Nightscout latest release resolver to use optional GitHub auth and fail on null/empty versions
- build the exact VERSION tag instead of cloning moving upstream default branch
- update to Node 22 for Nightscout 15.x engine requirements
- add a Mongo-backed Nightscout goss harness and HTTP status check

## Verification
- apps/nightscout/ci/latest.sh main -> v15.0.8
- metadata/goss/workflow YAML parsed successfully
- git diff --check passed
- full private-overlaid Docker build passed on Forge: remediate-nightscout:15.0.8
- runtime smoke with Mongo 4.4 passed: /api/v1/status.json -> 200, version 15.0.8
- Codex review: no blockers

Refs: Nightscout scheduled build failures for goss tcp:1337 timeout
