### PR TITLE
fix(nightscout): use HTTP health for runtime tests

### DIFF
--- a/apps/nightscout/ci/goss.yaml
+++ b/apps/nightscout/ci/goss.yaml
@@ -3,10 +3,6 @@ process:
   node:
     running: true
 
-port:
-  tcp:1337:
-    listening: true
-
 http:
   http://localhost:1337/api/v1/status.json:
     status: 200


### PR DESCRIPTION
Remove the brittle goss raw port assertion for Nightscout. The release job proved HTTP /api/v1/status.json reaches 200 while the port matcher kept failing under dgoss, so keep the process + HTTP checks that match the runtime contract.