### PR TITLE
ci(tooling): enable goss tests

### DIFF
--- a/apps/tooling/metadata.json
+++ b/apps/tooling/metadata.json
@@ -9,7 +9,7 @@
       ],
       "stable": true,
       "tests": {
-        "enabled": false,
+        "enabled": true,
         "type": "cli"
       }
     }


### PR DESCRIPTION
Enables the goss suite for the tooling image.

The tooling image is now the sidecar image for per-app user-restorable backups, so a missing or downlevel database client in it produces backups that silently write nothing — the exact failure mode that work exists to close. With tests disabled the only gate was a `RUN ... --version` line in the Dockerfile.

**Depends on elfhosted/containers-private#344 (already merged).** That PR repairs the goss suite, which asserted three scripts that have not existed since the scripts directory was reworked. It never failed a build because tests were off, so nothing evaluated it — enabling tests without that fix would have failed the first build on assertions unrelated to any actual problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)