### PR TITLE
fix(pulsarr): bump bun to 1.4.2 for upstream memory leak fix

### DIFF
--- a/apps/pulsarr/Dockerfile
+++ b/apps/pulsarr/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update && apk upgrade && \
 
 RUN git clone -b ${VERSION} https://github.com/jamcalli/pulsarr.git /source
 
-FROM oven/bun:1.4.1-alpine@sha256:2ef545220f7a886f22fcb3f2309bbd6bcf1c0aa04b7d79c31765c7aa4a13aac1 AS base
+FROM oven/bun:1.4.2-alpine@sha256:d888c0ae6c86d7866ff10c5aafdd9077b36aee6455b33dd270fb93c0dd5cef6f AS base
 WORKDIR /app
 
 # Install production dependencies in a temp directory (cached independently)

--- a/apps/pulsarr/develop/Dockerfile
+++ b/apps/pulsarr/develop/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update && apk upgrade && \
 
 RUN git clone -b develop https://github.com/jamcalli/pulsarr.git /source
 
-FROM oven/bun:1.4.1-alpine@sha256:2ef545220f7a886f22fcb3f2309bbd6bcf1c0aa04b7d79c31765c7aa4a13aac1 AS base
+FROM oven/bun:1.4.2-alpine@sha256:d888c0ae6c86d7866ff10c5aafdd9077b36aee6455b33dd270fb93c0dd5cef6f AS base
 WORKDIR /app
 
 # Install production dependencies in a temp directory (cached independently)


### PR DESCRIPTION
Follow-on to #877. Upstream pulsarr is moving to bun 1.4.2 to pick up a memory leak fix (develop `.bun-version` and `dockerfile`, jamcalli/pulsarr#1371 and #1372). No release cut yet, but the engines floor is still `>=1.4.0`, so the runtime bump is safe against the current v0.19.1.

- pin `oven/bun:1.4.2-alpine` by digest, matching upstream's pin
- same pin applied to the unbuilt `develop` channel Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
