### PR TITLE
fix(streamnzb,nzbdav): harden release resolvers

### DIFF
--- a/apps/nzbdav/ci/latest.sh
+++ b/apps/nzbdav/ci/latest.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Track latest stable Infinidysk (formerly nzbdav) release, while keeping the
-# ElfHosted container/app name `nzbdav`.
 headers=(-H "Accept: application/vnd.github+json")
 token="${TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN:-}}}"
 if [[ -n "${token}" ]]; then
   headers+=(-H "Authorization: Bearer ${token}")
 fi
-version=$(curl -fsSL "${headers[@]}"   https://api.github.com/repos/infinidysk/infinidysk/releases/latest   | jq -r '.tag_name')
+version=$(curl -fsSL "${headers[@]}" \
+  https://api.github.com/repos/infinidysk/infinidysk/releases/latest \
+  | jq -r '.tag_name // empty')
 if [[ -z "${version}" || "${version}" == "null" ]]; then
   echo "ERROR: nzbdav/infinidysk latest release resolved empty/null" >&2
   exit 1

--- a/apps/streamnzb/ci/latest.sh
+++ b/apps/streamnzb/ci/latest.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Track the latest upstream StreamNZB release for the image label. The
-# Dockerfile (containers-private) pins its own UPSTREAM_REF for the patch
-# series; when upstream releases run ahead of the pin, the label runs ahead
-# too until the series is rebased — same trade nzbdav accepts.
 headers=(-H "Accept: application/vnd.github+json")
 token="${TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN:-}}}"
 if [[ -n "${token}" ]]; then
@@ -12,7 +8,7 @@ if [[ -n "${token}" ]]; then
 fi
 version=$(curl -fsSL "${headers[@]}" \
   https://api.github.com/repos/Gaisberg/streamnzb/releases/latest \
-  | jq -r '.tag_name')
+  | jq -r '.tag_name // empty')
 if [[ -z "${version}" || "${version}" == "null" ]]; then
   echo "ERROR: streamnzb latest release resolved empty/null" >&2
   exit 1


### PR DESCRIPTION
## Summary
- Harden StreamNZB and NZBDAV latest release selectors to use TOKEN/GITHUB_TOKEN/GH_TOKEN correctly.
- Keep stdout version-only and fail loudly on empty/null GitHub release responses.

## Verification
- apps/streamnzb/ci/latest.sh main -> v5.17.0
- apps/nzbdav/ci/latest.sh main -> v1.3.0
- Full overlaid Docker builds passed for StreamNZB v5.17.0 and NZBDAV v1.3.0 using this public branch plus matching private branch.
- Runtime smokes passed: StreamNZB / -> 200; NZBDAV /ready -> 200 and /metrics -> 401.
