### PR TITLE
fix(harbor-site): sitemap covers the four pages the new static site added

### DIFF
--- a/apps/harbor-site/ci/goss.yaml
+++ b/apps/harbor-site/ci/goss.yaml
@@ -138,11 +138,18 @@ http:
     body:
       - "Sitemap: https://harbor.elfhosted.com/sitemap.xml"
 
+  # Every page the site links to, asserted individually. The static site added
+  # four pages in 1.5.1 and a sitemap that silently loses one is invisible --
+  # it stays valid XML and keeps returning 200.
   http://localhost:8080/sitemap.xml:
     status: 200
     timeout: 5000
     body:
       - "<loc>https://harbor.elfhosted.com/</loc>"
+      - "<loc>https://harbor.elfhosted.com/faq</loc>"
+      - "<loc>https://harbor.elfhosted.com/contributors</loc>"
+      - "<loc>https://harbor.elfhosted.com/legal</loc>"
+      - "<loc>https://harbor.elfhosted.com/privacy</loc>"
 
 file:
   # The resolver include is what makes proxy_pass with a variable host work. If

--- a/apps/harbor-site/ci/latest.sh
+++ b/apps/harbor-site/ci/latest.sh
@@ -58,5 +58,5 @@
 #          authenticated paths were fixed at Traefik; these four reach nginx.
 set -uo pipefail
 
-# 1.5.0: isolated, validated experimental update feed; normal channels unchanged.
-printf '%s' "1.5.0"
+# 1.5.1: sitemap covers the four pages the static site added.
+printf '%s' "1.5.1"

--- a/apps/harbor-site/sitemap.xml
+++ b/apps/harbor-site/sitemap.xml
@@ -1,8 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Served from the image, not the bucket. The 6-hourly VPS mirror used to revert
+  hand-fixes to this file silently; docs/19 section 4 in harbor-hosted records
+  why it moved here. A sitemap may only list URLs on the host that serves it,
+  so every entry below is harbor.elfhosted.com.
+
+  The paths are extensionless because that is what the site links to. The .html
+  twins exist only so old inbound links keep resolving, and listing both would
+  advertise duplicates. Anything Harbor routes client-side stays out, because
+  to a crawler that is a soft 404.
+-->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://harbor.elfhosted.com/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url><loc>https://harbor.elfhosted.com/faq</loc></url>
+  <url><loc>https://harbor.elfhosted.com/contributors</loc></url>
+  <url><loc>https://harbor.elfhosted.com/legal</loc></url>
+  <url><loc>https://harbor.elfhosted.com/privacy</loc></url>
 </urlset>


### PR DESCRIPTION
The apex marketing site was replaced today with the maintainer's static build — 204 objects uploaded to `elfhosted.com/site/apex/`, adding `/faq`, `/contributors`, `/legal` and `/privacy`.

The sitemap is served from **this image**, not the bucket, so it didn't come along with them and still advertised a single URL.

## Changes

- **`sitemap.xml`** — the four new pages, extensionless, matching what every internal link on the site uses. The `.html` twins exist only so old inbound links keep resolving; listing both forms would advertise four duplicates.
- **`ci/goss.yaml`** — asserts each page individually. A sitemap that loses an entry stays valid XML and keeps returning 200, so the previous single-URL check would have passed against a file with four pages missing.
- **`ci/latest.sh`** — 1.5.0 → 1.5.1.

## robots.txt is deliberately unchanged

The upstream package ships a `robots.txt` too, and it drops this line:

```
Content-Signal: search=yes,ai-input=yes,ai-train=yes
```

That is a decision of record rather than an oversight. `docs/19` §4 in harbor-hosted documents replacing Cloudflare's managed AI-crawler blocks with it, and says plainly that reversing it means telling us first. Our copy is otherwise a superset of theirs, so adopting their file would have silently reverted the policy and changed nothing else.

Flagged to the maintainer separately rather than actioned here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)