### PR TITLE
fix(harbor-site): buffer the experimental manifest subrequest, it 502s at 4k

### DIFF
--- a/apps/harbor-site/ci/goss.yaml
+++ b/apps/harbor-site/ci/goss.yaml
@@ -64,6 +64,18 @@ command:
   "awk '/server_name harbor.site/,/^}/' /etc/nginx/conf.d/harbor-site.conf | grep -q 'include /etc/nginx/snippets/harbor-updates.conf'":
     exit-status: 0
 
+  # The subrequest output buffer must be set on the location that SERVES the
+  # subrequest, not just on the two that issue it. Set only on the parents, this
+  # falls back to nginx's 4k default and every manifest larger than one memory
+  # page 502s with "too big subrequest response". That is not reachable from a
+  # runtime probe here -- with no credentials the handler fails closed at 503
+  # before any body is buffered -- so it is asserted against the config text.
+  # Anchored to the line start: this block's own comments name the directive,
+  # and an unanchored grep would be satisfied by the explanation of the bug
+  # rather than by the fix for it.
+  "awk '/location = \\/_harbor_experimental_manifest/,/^}/' /etc/nginx/snippets/harbor-updates.conf | grep -qE '^[[:space:]]*subrequest_output_buffer_size'":
+    exit-status: 0
+
   # And the negative: no redirect of any kind on /updates/ within that same block.
   # Asserting the include is present would still pass if a 308 were reintroduced
   # above it, because the first matching location wins.

--- a/apps/harbor-site/ci/latest.sh
+++ b/apps/harbor-site/ci/latest.sh
@@ -58,5 +58,5 @@
 #          authenticated paths were fixed at Traefik; these four reach nginx.
 set -uo pipefail
 
-# 1.5.1: sitemap covers the four pages the static site added.
-printf '%s' "1.5.1"
+# 1.5.2: subrequest_output_buffer_size on the manifest location; 4k default 502d.
+printf '%s' "1.5.2"

--- a/apps/harbor-site/harbor-updates.conf
+++ b/apps/harbor-site/harbor-updates.conf
@@ -61,6 +61,18 @@ location = /_harbor_experimental_manifest {
     proxy_cache off;
     proxy_buffer_size 128k;
     proxy_buffers 4 128k;
+    # HERE, not only on the parent locations. nginx allocates the subrequest
+    # output buffer in the context of the location that SERVES the subrequest,
+    # so the copies on /updates/latest-experimental.json and @experimental do
+    # not reach this one and it silently used the 4k default (one memory page).
+    #
+    # The first real manifest was 4,141 bytes and every request 502'd with
+    #   [error] too big subrequest response: 4141
+    # Forty-five bytes smaller and this would have shipped and looked correct.
+    # The goss check could not catch it either: with no credentials the handler
+    # fails closed at 503 before a body is ever buffered, so the assertion that
+    # proves the njs module loads is the same one that cannot exercise this.
+    subrequest_output_buffer_size 128k;
     error_page 403 404 = @experimental_missing;
 }
 


### PR DESCRIPTION
The experimental update feed returns **502 for every request** now that a real manifest has been published. From the pod's error log:

```
[error] too big subrequest response: 4141 while sending to client,
  request: "GET /updates/latest-experimental.json",
  subrequest: "/_harbor_experimental_manifest"
```

## Cause

`subrequest_output_buffer_size 128k` was set on the two locations that **issue** the subrequest (`/updates/latest-experimental.json` and `@experimental`) but not on the one that **serves** it. nginx allocates that buffer in the serving location's context, so `/_harbor_experimental_manifest` fell back to the 4 KiB default — one memory page.

The first published manifest is **4,141 bytes**. Forty-five bytes smaller and this would have shipped, worked, and waited to break on whichever release first added a platform.

## Why neither test caught it

The goss check asserts **503** on that endpoint, and that assertion is correct — with no credentials in the test container the handler must fail closed rather than fall through to the stable feed. But failing closed happens *before any response body is buffered*, so the check that proves the njs module parses and loads is structurally unable to exercise the path that buffers a body.

The unit tests evaluate the module under Node, which has no subrequests at all.

So this is asserted against the config text instead: the directive must appear inside the `/_harbor_experimental_manifest` block. Anchored to line start, because that block's own comments now name the directive and an unanchored grep would be satisfied by the *explanation* of the bug rather than the fix for it.

Verified three ways:

| File | Result |
|---|---|
| this branch | exit 0, passes |
| `origin/main` (pre-fix) | exit 1, correctly fails |
| directive present only in a comment | exit 1, correctly fails |

`ci/latest.sh` → 1.5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)