### PR TITLE
feat(xrdb): build metadata for the public instance image

### DIFF
--- a/apps/xrdb/ci/latest.sh
+++ b/apps/xrdb/ci/latest.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# XRDB -- eXtended Ratings DataBase.
+# Source: https://github.com/IbbyLabs/XRDB (public)
+#
+# The Dockerfile and the patch stack live in containers-private, because the
+# upstream repo declares no licence. Only the build metadata is here.
+#
+# Releases are cut by release-please from conventional commits on main, so
+# releases/latest is always the newest server build. Tags are vN.N.N.
+
+set -euo pipefail
+
+repo="IbbyLabs/XRDB"
+
+headers=(-H "Accept: application/vnd.github+json")
+if [[ -n "${TOKEN:-${GITHUB_TOKEN:-}}" ]]; then
+  headers+=(-H "Authorization: Bearer ${TOKEN:-${GITHUB_TOKEN:-}}")
+fi
+
+# Take the newest published, non-draft release whose tag is a v3-or-later
+# version. v2 is a different application: it listened on 3000, kept its data
+# somewhere else, and its profiles do not carry into v3. Pinning the major here
+# means a v2 maintenance release cannot roll the public instance backwards onto
+# a schema our patches do not fit.
+version=""
+for page in 1 2 3; do
+  version=$(curl -fsSL "${headers[@]}" \
+    "https://api.github.com/repos/${repo}/releases?per_page=100&page=${page}" \
+    | jq --raw-output '[.[] | select(.draft == false and .prerelease == false)
+                          | .tag_name | select(test("^v[3-9][0-9]*\\."))] | first // empty')
+  if [[ -n "${version}" ]]; then
+    break
+  fi
+done
+
+if [[ -z "${version}" ]]; then
+  echo "ERROR: no ${repo} release (v3+) in the 300 most recent releases" >&2
+  exit 1
+fi
+
+printf "%s" "${version}"

--- a/apps/xrdb/metadata.json
+++ b/apps/xrdb/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "xrdb",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Build metadata for XRDB, which ElfHosted is hosting a public instance of at IbbyLabs' invitation.

The Dockerfile and the four-patch stack live in [containers-private#350](https://github.com/elfhosted/containers-private/pull/350), because upstream ([IbbyLabs/XRDB](https://github.com/IbbyLabs/XRDB)) declares no licence. Only the build metadata belongs here.

## Notes

- `tests.enabled: true`, type `web`. `ci/goss.yaml` (in containers-private, alongside the Dockerfile) checks `/healthz`, that the embedded configurator is actually present, and the Stremio manifest. The UI check earns its place: a web-builder stage that produced nothing still yields a Go binary that serves the API happily and 404s the UI.
- `ci/latest.sh` pins the major to **v3+**. v2 is a different application, on a different port with a different data layout and profiles that do not carry forward, so a v2 maintenance release must not be able to resolve here and roll the public instance backwards onto a schema the patches do not fit. Verified it resolves `v3.110.0` today.
- Single channel, `linux/amd64`, matching the other public-instance addons.

Being a new app, this needs a manual `Release: Manual` run (app `xrdb`, channel `main`) rather than waiting on the schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)