### PR TITLE
feat(jellystreams): add build metadata

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# `jellystreams` is our own code — a Jellyfin front end for a tenant's
+# AIOStreams configuration — so there is no upstream release to track and
+# renovate has nothing to watch. The version is declared here and bumped by
+# hand.
+#
+# Bump this when apps/jellystreams/ changes in containers-private. Without a
+# bump the tag stays put across rebuilds, and imagePullPolicy: IfNotPresent
+# leaves nodes that already cached it running the OLD build forever. The chart
+# pins the digest for exactly that reason, but a moving tag is still the
+# clearer signal.
+printf "%s" "0.1.0"

--- a/apps/jellystreams/metadata.json
+++ b/apps/jellystreams/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "jellystreams",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Build config for a new private-source app. The Dockerfile and source live in containers-private (`apps/jellystreams`); only the build declaration is public, matching how `parent` and `pinepods-ai` are wired.

jellystreams serves a tenant's AIOStreams configuration to Jellyfin clients. It has no upstream, so `latest.sh` declares the version by hand — bump it whenever `apps/jellystreams/` changes in containers-private, or a rebuild reuses the tag and `IfNotPresent` nodes keep serving the old binary.

goss tests are enabled: the image starts without a `SECRET_KEY` and still answers `/health` and the unauthenticated Jellyfin discovery endpoints, which is exactly what can be checked in isolation. Verified by running the image under `--user 568:568 --read-only`.

Pairs with elfhosted/containers-private#353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)