### PR TITLE
feat(jellystreams): 0.2.0

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.1.0"
+printf "%s" "0.2.0"


### PR DESCRIPTION
Version bump so the rebuild produces a new tag. Pairs with the containers-private change that moves browsing onto a metadata board (Cinemeta via emdb) instead of the tenant's AIOStreams catalogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)