### PR TITLE
feat(jellystreams): 0.5.0

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.4.0"
+printf "%s" "0.5.0"


### PR DESCRIPTION
Artwork served as bytes (why Infuse showed no posters), `/Items/` with a trailing slash, and real ffprobe track data from RemuxDB via emdb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)