### PR TITLE
feat(jellystreams): 0.8.0

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.7.0"
+printf "%s" "0.8.0"


### PR DESCRIPTION
Skip intro via IntroDB (through emdb v0.7.0), and a 90s stream-list cache that collapses the ~12s delay after pressing Play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)