### PR TITLE
fix(jellystreams): 0.9.1, detail-page extras answer with an empty list

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.9.0"
+printf "%s" "0.9.1"


### PR DESCRIPTION
Version bump for elfhosted/containers-private#365: `/Items/{id}/LocalTrailers` and `/Items/{id}/SpecialFeatures` now return an empty array instead of a 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)