### PR TITLE
fix(jellystreams): 0.10.0, playable lists carry sources and films offer all of them

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.9.1"
+printf "%s" "0.10.0"


### PR DESCRIPTION
Version bump for elfhosted/containers-private#366 — fixes both tenant reports: movies vanishing from search (Infuse silently drops playable items with no MediaSources) and no version picker (a movie's detail page now advertises every release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)