### PR TITLE
fix(jellystreams): 0.10.1, a movie's default source carries the item's id

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.10.0"
+printf "%s" "0.10.1"


### PR DESCRIPTION
Version bump for elfhosted/containers-private#367 — aligns the detail-page source list with the Jellyfin fork that does show a version picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)