### PR TITLE
perf(jellystreams): 0.10.2, resolve a title's streams once per burst

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.10.1"
+printf "%s" "0.10.2"


### PR DESCRIPTION
Version bump for elfhosted/containers-private#368 — six concurrent plays cost six upstream stream resolutions before, one after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)