### PR TITLE
fix(jellystreams): 0.11.0, missing metadata no longer kills a detail page

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.10.2"
+printf "%s" "0.11.0"


### PR DESCRIPTION
Version bump for elfhosted/containers-private#369 — found by running the Jellyfin fork beside us on identical data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)