### PR TITLE
fix(jellystreams): 0.11.1, single-video containers play through their video

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.0"
+printf "%s" "0.11.1"


### PR DESCRIPTION
Version bump for elfhosted/containers-private#371 — fixes grainy's TorBox catalog slating on every play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)