### PR TITLE
feat(privatebin): add build metadata and version discovery

### DIFF
--- a/apps/privatebin/ci/latest.sh
+++ b/apps/privatebin/ci/latest.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# PrivateBin tags releases without a "v" prefix (2.0.6), which is also the tag
+# the source archive is fetched by, so no rewriting is needed.
+version=$(curl -L -sX GET "https://api.github.com/repos/PrivateBin/PrivateBin/releases/latest" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.tag_name')
+version="${version#*v}"
+printf "%s" "${version}"

--- a/apps/privatebin/metadata.json
+++ b/apps/privatebin/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "privatebin",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Companion to elfhosted/containers-private#372, which carries the Dockerfile.

PrivateBin returns to the catalogue as a Flex collection candidate (F0.5 of `PLAN-flex-tiers`). It was removed in 2025-08 carrying an unexplained `readOnlyRootFilesystem: false`; the cause turned out to be two missing volume mounts rather than anything about the app, and the new image runs read-only as 568 with a verified paste round-trip.

- `metadata.json` follows wallos: single amd64 channel, stable, web tests enabled so the goss suite in containers-private runs against the built image.
- `ci/latest.sh` reads the upstream release tag. PrivateBin tags without a `v` prefix (2.0.6) and the source archive is fetched by that same tag, so the prefix strip is a no-op kept for consistency. The jq path returns 2.0.6 unauthenticated; an empty `TOKEN` yields `null` here exactly as it does for wallos, so that is the token and not the script.

**A push only runs CodeQL** — this needs a `Release: Manual` dispatch before an image is built and published, and the myprecious chart entry cannot land until there is a digest to pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)