### PR TITLE
fix(jellystreams): 0.11.2, items carry an Etag so the picker needs no refresh

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.1"
+printf "%s" "0.11.2"


### PR DESCRIPTION
Version bump for elfhosted/containers-private#373 — Infuse ignored the real source list without an Etag; now the picker appears without a manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)