### PR TITLE
fix(jellystreams): 0.11.3, concise resolution-first source labels

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.2"
+printf "%s" "0.11.3"


### PR DESCRIPTION
Version bump for elfhosted/containers-private#374 — version picker chips now lead with resolution/quality/size, formatter-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)