### PR TITLE
feat(wikijs): add build metadata and version discovery

### DIFF
--- a/apps/wikijs/ci/latest.sh
+++ b/apps/wikijs/ci/latest.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# GitHub's releases/latest excludes prereleases, which matters here: Wiki.js
+# publishes 3.0.0-beta.* continuously while 2.x remains the stable line, so
+# /releases would return a beta and /releases/latest correctly returns 2.5.314.
+version=$(curl -L -sX GET "https://api.github.com/repos/requarks/wiki/releases/latest" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.tag_name')
+version="${version#*v}"
+printf "%s" "${version}"

--- a/apps/wikijs/metadata.json
+++ b/apps/wikijs/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "wikijs",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Companion to elfhosted/containers-private#375. The chart referenced `ghcr.io/elfhosted/wikijs` with no build definition anywhere, so pulls failed with `not found`.

`latest.sh` uses `/releases/latest` deliberately rather than `/releases`: Wiki.js publishes `3.0.0-beta.*` continuously while 2.x remains the stable line, so `/releases` returns a prerelease and `/releases/latest` correctly returns `2.5.314` — the tag the chart already pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)