### PR TITLE
fix(wikijs): disable standalone tests, they cannot pass without a database

### DIFF
--- a/apps/wikijs/metadata.json
+++ b/apps/wikijs/metadata.json
@@ -9,7 +9,7 @@
       ],
       "stable": true,
       "tests": {
-        "enabled": true,
+        "enabled": false,
         "type": "web"
       }
     }


### PR DESCRIPTION
Follow-up to #905. The first build ([run 34284616916](https://github.com/elfhosted/containers/actions/runs/34284616916)) built the image fine but failed its goss run:

```
[MASTER] error: Invalid DB Type
http://localhost:3000/: dial tcp [::1]:3000: connect: connection refused
```

Wiki.js refuses to start without a database, so it never binds 3000 and the HTTP check cannot pass in a standalone container.

I verified the image locally **with** a `postgres:17-alpine` sidecar — which is exactly why this was missed. CI runs the image alone.

Follows the adventurelog precedent: tests disabled in `metadata.json`, with the checks kept in `goss.yaml` (elfhosted/containers-private#376) documenting what to assert when the app runs alongside its sidecars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)