### PR TITLE
fix(jellystreams): 0.11.4, MediaSourceCount hint for the version picker

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.3"
+printf "%s" "0.11.4"


### PR DESCRIPTION
Version bump for elfhosted/containers-private#377 — experimental: placeholder hints MediaSourceCount>1 so Infuse builds the picker without a manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)