### PR TITLE
feat(bookstack): add build metadata and version discovery

### DIFF
--- a/apps/bookstack/ci/latest.sh
+++ b/apps/bookstack/ci/latest.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# BookStack tags releases as vYY.MM.patch (v26.05.4); the leading v is stripped
+# for the image tag but re-added when fetching the source archive.
+version=$(curl -L -sX GET "https://api.github.com/repos/BookStackApp/BookStack/releases/latest" --header "Authorization: Bearer ${TOKEN}" | jq --raw-output '.tag_name')
+version="${version#*v}"
+printf "%s" "${version}"

--- a/apps/bookstack/metadata.json
+++ b/apps/bookstack/metadata.json
@@ -1,0 +1,17 @@
+{
+  "app": "bookstack",
+  "base": false,
+  "channels": [
+    {
+      "name": "main",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "web"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Companion to elfhosted/containers-private#377.

Tests disabled from the outset: BookStack runs `php artisan migrate` before php-fpm serves traffic, so it cannot start without a database and never binds :8080 standalone. Same as adventurelog and wikijs — shipping it disabled rather than discovering it in a failed build, as happened with wikijs in #905.

`latest.sh` strips the leading `v` from `vYY.MM.patch` tags; the Dockerfile re-adds it when fetching the source archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)