### PR TITLE
revert(jellystreams): 0.11.5, drop the MediaSourceCount placeholder hint

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.4"
+printf "%s" "0.11.5"


### PR DESCRIPTION
Version bump for elfhosted/containers-private#379 — the picker hint had no effect on iOS; reverted the placeholder lie, kept the honest detail count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)