### PR TITLE
fix(jellystreams): 0.11.7, stop leaking the session token in MediaSource Paths

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.6"
+printf "%s" "0.11.7"


### PR DESCRIPTION
Version bump for the source fix in elfhosted/containers-private#383: the raw session token no longer rides in `MediaSource.Path`; it is replaced by an item-bound, stream-only sealed capability. Reviewed across codex + a fable adversarial pass; live-verified against real AIOStreams + Real-Debrid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)