### PR TITLE
fix(jellystreams): 0.11.13, collage thumbnails for category folders (Android TV)

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.12"
+printf "%s" "0.11.13"


### PR DESCRIPTION
Bumps jellystreams to 0.11.13. Composes a 2×2 poster collage for category folders ("Popular", "New") that previously rendered a blank tile on the Shield.

Source change: elfhosted/containers-private#389 (merged). Session-gated per-account, decode-bomb-guarded, singleflight-coalesced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)