### PR TITLE
fix(jellystreams): 0.11.14, one lazy placeholder for episodes (Infuse picker)

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.13"
+printf "%s" "0.11.14"


### PR DESCRIPTION
Bumps jellystreams to 0.11.14. Episodes get a single lazy placeholder so Infuse no longer shows a hollow version picker (duplicate "(more versions)" entry). Source: elfhosted/containers-private#390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)