### PR TITLE
fix(jellystreams): 0.11.15, populate the Next Up row

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.14"
+printf "%s" "0.11.15"


### PR DESCRIPTION
Bumps jellystreams to 0.11.15. `/Shows/NextUp` now surfaces the next unwatched episode per in-progress series (was always empty). Source: elfhosted/containers-private#391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)