### PR TITLE
fix(jellystreams): 0.11.16, discovery (cast, appears-in, More Like This)

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.15"
+printf "%s" "0.11.16"


### PR DESCRIPTION
Bumps jellystreams to 0.11.16 — cast list (People), person filmography (`/Items?personIds=`), and genre-based `/Items/{id}/Similar`. Source: elfhosted/containers-private#392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)