### PR TITLE
fix(jellystreams): 0.11.17, close API-coverage gaps from an endpoint audit

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.16"
+printf "%s" "0.11.17"


### PR DESCRIPTION
Bumps jellystreams to 0.11.17 — Similar type-aliases, real `/Genres` + filter descriptors + genre browsing, `/Movies/Recommendations`, `/Items/{id}/Ancestors`, a browsable root, and polite answers where we used to 404. Source: elfhosted/containers-private#393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)