### PR TITLE
fix(jellystreams): 0.11.18, episode pickers, honest filmography, better collages

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.17"
+printf "%s" "0.11.18"


### PR DESCRIPTION
Bumps jellystreams to 0.11.18. Source: elfhosted/containers-private#394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)