### PR TITLE
fix(jellystreams): 0.11.19, restore the picker trigger on episodes

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.18"
+printf "%s" "0.11.19"


### PR DESCRIPTION
TV shows had no source picker. Restores the two list placeholders that trigger it, now that detail resolves real releases. Source: elfhosted/containers-private#395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)