### PR TITLE
fix(jellystreams): 0.11.20, metadata enrichment (logos, cast photos, trailers)

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.19"
+printf "%s" "0.11.20"


### PR DESCRIPTION
Bumps jellystreams to 0.11.20. Source: elfhosted/containers-private#399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)