### PR TITLE
fix(jellystreams): 0.11.21, artwork fallback, faster cast row, AIOMetadata board

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.20"
+printf "%s" "0.11.21"


### PR DESCRIPTION
Artwork falls back when an upstream URL is dead (titles with no art), cast row no longer takes 13s, root/favicon answer, and AIOMETADATA_URL points the board at an AIOMetadata install. Source: elfhosted/containers-private#402, #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)