### PR TITLE
fix(jellystreams): 0.11.23, landscape collages, pre-warming, logo

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.22"
+printf "%s" "0.11.23"


### PR DESCRIPTION
Collages are now landscape (matching Jellyfin library cards) and prefer landscape art, so poster detail is no longer cropped. Plus background pre-warming, build timing, bounded artwork fallback, and the ElfHosted mark in the panel. Source: elfhosted/containers-private#408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)