### PR TITLE
fix(jellystreams): 0.11.24, persist collage cache to disk

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.23"
+printf "%s" "0.11.24"


### PR DESCRIPTION
Built tiles now survive restarts, removing the per-shelf rebuild cost. Source: elfhosted/containers-private#409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)