### PR TITLE
fix(jellystreams): 0.11.25, profiles sign in from a client

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.11.24"
+printf "%s" "0.11.25"


### PR DESCRIPTION
Household members appear in the Jellyfin user picker and sign in with their own PIN. Includes the persisted collage cache from 0.11.24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)