### PR TITLE
chore(jellystreams): 0.24.0

### DIFF
--- a/apps/jellystreams/ci/latest.sh
+++ b/apps/jellystreams/ci/latest.sh
@@ -9,4 +9,4 @@
 # leaves nodes that already cached it running the OLD build forever. The chart
 # pins the digest for exactly that reason, but a moving tag is still the
 # clearer signal.
-printf "%s" "0.23.0"
+printf "%s" "0.24.0"


### PR DESCRIPTION
Version bump for elfhosted/containers-private#440.

Catalogues browsed from Jellyfin Android TV were empty — the client hands our ids back as dashed GUIDs in the query string, where path normalisation never reached them. Library tiles are now one dimmed poster drawn in the shape the client asks for, rather than a duotone grid squared off for everybody, and the Jellyfin web client can fetch one without a token.

Minor rather than patch: the tile look changes and the admin panel's Connect card is reordered, so the bump should be visible rather than quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)